### PR TITLE
docs: 添加最新版下载量徽章显示下载统计信息

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -6,6 +6,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=星标)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/stargazers)
 [![Total Downloads](https://img.shields.io/github/downloads/RavenHogWarts/obsidian-ace-code-editor/total?style=flat&label=总下载量)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/releases)
+[![Latest Downloads](https://img.shields.io/github/downloads/RavenHogWarts/obsidian-ace-code-editor/latest/total?style=flat&label=最新版下载量)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/releases/latest)
 [![GitHub License](https://img.shields.io/github/license/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=许可证)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/blob/master/LICENSE)
 [![GitHub Issues](https://img.shields.io/github/issues/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=问题)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/issues)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=最后提交)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/commits/master)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An enhanced code editor using Ace editor, providing syntax highlighting, code fo
 
 [![GitHub stars](https://img.shields.io/github/stars/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=Stars)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/stargazers)
 [![Total Downloads](https://img.shields.io/github/downloads/RavenHogWarts/obsidian-ace-code-editor/total?style=flat&label=Total%20Downloads)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/releases)
+[![Latest Downloads](https://img.shields.io/github/downloads/RavenHogWarts/obsidian-ace-code-editor/latest/total?style=flat&label=Latest%20Downloads)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/releases/latest)
 [![GitHub License](https://img.shields.io/github/license/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=License)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/blob/master/LICENSE)
 [![GitHub Issues](https://img.shields.io/github/issues/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=Issues)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/issues)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=Last%20Commit)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/commits/master)


### PR DESCRIPTION
在 README.md 和 README-zh.md 中新增“最新版下载量”徽章，
方便用户快速查看最新版本的下载次数，提升项目展示效果。