### PR TITLE
feat: 增加快捷键 Alt + P 打开obsidian命令面板

### DIFF
--- a/src/type/obsidian-extend.d.ts
+++ b/src/type/obsidian-extend.d.ts
@@ -6,6 +6,7 @@ declare module "obsidian" {
 		openWithDefaultApp(path: string): void;
 		embedRegistry: EmbedRegistry;
 		customCss: CustomCSS;
+		commands: Commands;
 	}
 	interface Plugins {
 		disablePluginAndSave(id: string): Promise<void>;
@@ -45,4 +46,8 @@ interface CustomCSS extends Component {
 	enabledSnippets: Set<string>;
 	requestLoadSnippets: Debouncer<[], void>;
 	setCssEnabledStatus(snippetName: string, enabled: boolean): void;
+}
+
+interface Commands {
+	executeCommandById(commandId: string): boolean;
 }

--- a/src/utils/ObsidianUtils.ts
+++ b/src/utils/ObsidianUtils.ts
@@ -12,4 +12,8 @@ export class ObsidianUtils {
 			throw new Error("[ace-code-editor] 插件重载失败" + error);
 		}
 	}
+
+	static async runCommandById(app: App, commandId: string) {
+		app.commands.executeCommandById(commandId);
+	}
 }

--- a/src/view/CodeEditorView.tsx
+++ b/src/view/CodeEditorView.tsx
@@ -1,6 +1,7 @@
 import type AceCodeEditorPlugin from "@/src/main";
 import { AceService } from "@/src/service/AceService";
 import { CODE_EDITOR_VIEW_TYPE, ICodeEditorConfig } from "@/src/type/types";
+import { ObsidianUtils } from "@/src/utils/ObsidianUtils";
 import { IconName, Scope, TextFileView, TFile, WorkspaceLeaf } from "obsidian";
 
 export class CodeEditorView extends TextFileView {
@@ -32,39 +33,8 @@ export class CodeEditorView extends TextFileView {
 			})
 		);
 
-		// 启用Ace快捷键绑定
 		this.registerAceKeybindings();
-
-		this.registerDomEvent(
-			this.editorElement,
-			"focus",
-			() => {
-				this.app.keymap.pushScope(this.editorScope);
-			},
-			true
-		);
-
-		this.registerDomEvent(
-			this.editorElement,
-			"blur",
-			() => {
-				this.app.keymap.popScope(this.editorScope);
-			},
-			true
-		);
-
-		// 注册滚轮事件用于字体大小调整
-		this.registerDomEvent(
-			this.editorElement,
-			"wheel",
-			(event: WheelEvent) => {
-				if (event.ctrlKey || event.metaKey) {
-					event.preventDefault();
-					this.handleFontSizeChange(event.deltaY);
-				}
-			},
-			{ passive: false }
-		);
+		this.registerDomEvents();
 	}
 
 	async onLoadFile(file: TFile) {
@@ -140,6 +110,47 @@ export class CodeEditorView extends TextFileView {
 				`ace/keyboard/${this.config.keyboard}`
 			);
 		}
+
+		// 注册快捷键：Alt+P 打开命令面板
+		this.editorScope.register(["Alt"], "p", (event: KeyboardEvent) => {
+			event.preventDefault();
+			event.stopPropagation();
+			ObsidianUtils.runCommandById(this.app, "command-palette:open");
+			return false;
+		});
+	}
+
+	private registerDomEvents() {
+		this.registerDomEvent(
+			this.editorElement,
+			"focus",
+			() => {
+				this.app.keymap.pushScope(this.editorScope);
+			},
+			true
+		);
+
+		this.registerDomEvent(
+			this.editorElement,
+			"blur",
+			() => {
+				this.app.keymap.popScope(this.editorScope);
+			},
+			true
+		);
+
+		// 注册滚轮事件用于字体大小调整
+		this.registerDomEvent(
+			this.editorElement,
+			"wheel",
+			(event: WheelEvent) => {
+				if (event.ctrlKey || event.metaKey) {
+					event.preventDefault();
+					this.handleFontSizeChange(event.deltaY);
+				}
+			},
+			{ passive: false }
+		);
 	}
 
 	private handleFontSizeChange(deltaY: number) {


### PR DESCRIPTION
因为obsidian快捷键和ace快捷键会有一部分冲突，所以在编辑器页面并不能使用obsidian快捷键

增加一个不常用的快捷键来在代码编辑器页面能够打开obsidian命令面板，以此能够使用到obsidian的原生功能

