### PR TITLE
style: 引入 AceView 样式并限制编辑器溢出

### DIFF
--- a/style/AceView.css
+++ b/style/AceView.css
@@ -1,0 +1,5 @@
+.workspace-leaf-content[data-type="ace-code-editor"] {
+	.view-content {
+		overflow: hidden;
+	}
+}

--- a/style/styles.ts
+++ b/style/styles.ts
@@ -1,4 +1,5 @@
 import "./AceEmbedView.css";
+import "./AceView.css";
 import "./BaseModal.css";
 import "./CreateCodeFileModal.css";
 import "./EditCodeBlockModal.css";


### PR DESCRIPTION
- 在样式入口文件中导入了 AceView.css
- 新增 AceView.css 文件
- 为 data-type="ace-code-editor" 的 workspace 视图内 .view-content 添加 overflow: hidden 规则，以防止 Ace 编辑器出现滚动或内容溢出，改善布局一致性并避免布局抖动