### PR TITLE
feat: 引入存储与订阅机制

### DIFF
--- a/src/context/SettingsStoreContext.tsx
+++ b/src/context/SettingsStoreContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import SettingsStore from "../settings/SettingsStore";
+
+export const SettingsStoreContext = createContext<SettingsStore | undefined>(
+	undefined
+);

--- a/src/hooks/usePluginSettings.tsx
+++ b/src/hooks/usePluginSettings.tsx
@@ -1,0 +1,13 @@
+import { useSyncExternalStore } from "react";
+import SettingsStore from "../settings/SettingsStore";
+import { ICodeEditorConfig } from "../type/types";
+
+export default function usePluginSettings(
+	settingsStore: SettingsStore
+): ICodeEditorConfig {
+	const settings = useSyncExternalStore(
+		settingsStore.store.subscribe,
+		settingsStore.store.getSnapshot
+	);
+	return settings;
+}

--- a/src/hooks/useSettingsStore.tsx
+++ b/src/hooks/useSettingsStore.tsx
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+import { SettingsStoreContext } from "../context/SettingsStoreContext";
+import SettingsStore from "../settings/SettingsStore";
+
+export default function useSettingsStore(): SettingsStore {
+	const store = useContext(SettingsStoreContext);
+	if (!store) {
+		throw new Error(
+			"useSettingsStore must be used within a SettingsProvider"
+		);
+	}
+	return store;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { BaseModal } from "./component/modal/BaseModal";
 import { QuickConfigModal } from "./component/modal/QuickConfigModal";
 import { SettingsBus } from "./hooks/useSettings";
 import { t } from "./i18n/i18n";
+import SettingsStore from "./settings/SettingsStore";
 import AceCodeEditorSettingTab from "./settings/SettingsTab";
 import { EmbedCreator } from "./type/obsidian-extend";
 import {
@@ -20,6 +21,7 @@ import { SETTINGS_VIEW_TYPE, SettingsView } from "./view/SettingsView";
 export default class AceCodeEditorPlugin extends Plugin {
 	settings: ICodeEditorConfig;
 	statusBar: HTMLElement;
+	readonly settingsStore = new SettingsStore(this);
 
 	async onload() {
 		await this.loadSettings();

--- a/src/settings/AceSettings.tsx
+++ b/src/settings/AceSettings.tsx
@@ -12,10 +12,11 @@ import {
 	AceKeyboardList,
 	AceLightThemesList,
 } from "@/src/service/AceThemes";
-import { ICodeEditorConfig } from "@/src/type/types";
 import parse from "html-react-parser";
 import { Notice, Platform } from "obsidian";
 import * as React from "react";
+import usePluginSettings from "../hooks/usePluginSettings";
+import useSettingsStore from "../hooks/useSettingsStore";
 import { SettingsItem } from "./item/SettingItem";
 
 interface FontData {
@@ -37,12 +38,15 @@ interface AceSettingsProps {
 }
 
 export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
-	const [settingsValue, setSettingsValue] = React.useState(plugin.settings);
+	// const [settingsValue, setSettingsValue] = React.useState(plugin.settings);
+	const settingsStore = useSettingsStore();
+	const settings = usePluginSettings(settingsStore);
+	const app = settingsStore.app;
 
 	// 监听外部settings变化，同步到本地状态
-	React.useEffect(() => {
-		setSettingsValue(plugin.settings);
-	}, [plugin.settings]);
+	// React.useEffect(() => {
+	// 	setSettingsValue(plugin.settings);
+	// }, [plugin.settings]);
 
 	const [systemFonts, setSystemFonts] = React.useState<string[]>([]);
 
@@ -231,15 +235,15 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 		});
 	}
 
-	const handleUpdateConfig = React.useCallback(
-		async (newSettings: Partial<ICodeEditorConfig>) => {
-			const updatedSettings = { ...settingsValue, ...newSettings };
-			setSettingsValue(updatedSettings);
-			// 直接调用plugin.updateSettings，避免useEffect带来的副作用
-			await plugin.updateSettings(newSettings);
-		},
-		[settingsValue, plugin]
-	);
+	// const handleUpdateConfig = React.useCallback(
+	// 	async (newSettings: Partial<ICodeEditorConfig>) => {
+	// 		const updatedSettings = { ...settingsValue, ...newSettings };
+	// 		setSettingsValue(updatedSettings);
+	// 		// 直接调用plugin.updateSettings，避免useEffect带来的副作用
+	// 		await plugin.updateSettings(newSettings);
+	// 	},
+	// 	[settingsValue, plugin]
+	// );
 
 	const lightThemeOptions = React.useMemo(
 		() =>
@@ -281,9 +285,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 				>
 					<Select
 						options={lightThemeOptions}
-						value={settingsValue.lightTheme}
+						value={settings.lightTheme}
 						onChange={(value) =>
-							handleUpdateConfig({ lightTheme: value as string })
+							settingsStore.updateSettingByPath(
+								"lightTheme",
+								value as string
+							)
 						}
 					/>
 				</SettingsItem>
@@ -294,9 +301,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 				>
 					<Select
 						options={darkThemeOptions}
-						value={settingsValue.darkTheme}
+						value={settings.darkTheme}
 						onChange={(value) =>
-							handleUpdateConfig({ darkTheme: value as string })
+							settingsStore.updateSettingByPath(
+								"darkTheme",
+								value as string
+							)
 						}
 					/>
 				</SettingsItem>
@@ -308,9 +318,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					defaultCollapsed={false}
 				>
 					<TagInput
-						values={settingsValue.fontFamily}
+						values={settings.fontFamily}
 						onChange={(value) =>
-							handleUpdateConfig({ fontFamily: value })
+							settingsStore.updateSettingByPath(
+								"fontFamily",
+								value
+							)
 						}
 						suggestions={systemFonts}
 						placeholder={t("setting.fontFamily.placeholder")}
@@ -333,9 +346,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 				>
 					<Input
 						type="number"
-						value={settingsValue.fontSize}
+						value={settings.fontSize}
 						onChange={(value) =>
-							handleUpdateConfig({ fontSize: Number(value) })
+							settingsStore.updateSettingByPath(
+								"fontSize",
+								Number(value)
+							)
 						}
 					/>
 				</SettingsItem>
@@ -345,9 +361,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					desc={t("setting.showLineNumbers.desc")}
 				>
 					<Toggle
-						checked={settingsValue.showLineNumbers}
+						checked={settings.showLineNumbers}
 						onChange={(value) =>
-							handleUpdateConfig({ showLineNumbers: value })
+							settingsStore.updateSettingByPath(
+								"showLineNumbers",
+								value
+							)
 						}
 					/>
 				</SettingsItem>
@@ -357,9 +376,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					desc={t("setting.showPrintMargin.desc")}
 				>
 					<Toggle
-						checked={settingsValue.showPrintMargin}
+						checked={settings.showPrintMargin}
 						onChange={(value) =>
-							handleUpdateConfig({ showPrintMargin: value })
+							settingsStore.updateSettingByPath(
+								"showPrintMargin",
+								value
+							)
 						}
 					/>
 				</SettingsItem>
@@ -369,9 +391,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					desc={t("setting.showInvisibles.desc")}
 				>
 					<Toggle
-						checked={settingsValue.showInvisibles}
+						checked={settings.showInvisibles}
 						onChange={(value) =>
-							handleUpdateConfig({ showInvisibles: value })
+							settingsStore.updateSettingByPath(
+								"showInvisibles",
+								value
+							)
 						}
 					/>
 				</SettingsItem>
@@ -381,9 +406,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					desc={t("setting.displayIndentGuides.desc")}
 				>
 					<Toggle
-						checked={settingsValue.displayIndentGuides}
+						checked={settings.displayIndentGuides}
 						onChange={(value) =>
-							handleUpdateConfig({ displayIndentGuides: value })
+							settingsStore.updateSettingByPath(
+								"displayIndentGuides",
+								value
+							)
 						}
 					/>
 				</SettingsItem>
@@ -393,15 +421,18 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					desc={t("setting.showFoldWidgets.desc")}
 				>
 					<Toggle
-						checked={settingsValue.showFoldWidgets}
+						checked={settings.showFoldWidgets}
 						onChange={(value) =>
-							handleUpdateConfig({ showFoldWidgets: value })
+							settingsStore.updateSettingByPath(
+								"showFoldWidgets",
+								value
+							)
 						}
 					/>
 				</SettingsItem>
 			</>
 		);
-	}, [settingsValue, systemFonts, handleUpdateConfig]);
+	}, [settings, systemFonts]);
 
 	const SessionSettings = React.useMemo(() => {
 		return (
@@ -413,9 +444,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					defaultCollapsed={false}
 				>
 					<TagInput
-						values={settingsValue.supportExtensions}
+						values={settings.supportExtensions}
 						onChange={(value) =>
-							handleUpdateConfig({ supportExtensions: value })
+							settingsStore.updateSettingByPath(
+								"supportExtensions",
+								value
+							)
 						}
 						placeholder={t("setting.supportExtensions.placeholder")}
 						suggestions={Object.values(languageModeMap).flat()}
@@ -428,9 +462,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 				>
 					<Select
 						options={keyboardOptions}
-						value={settingsValue.keyboard}
+						value={settings.keyboard}
 						onChange={(value) =>
-							handleUpdateConfig({ keyboard: value as string })
+							settingsStore.updateSettingByPath(
+								"keyboard",
+								value as string
+							)
 						}
 					/>
 				</SettingsItem>
@@ -441,9 +478,12 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 				>
 					<Input
 						type="number"
-						value={settingsValue.tabSize}
+						value={settings.tabSize}
 						onChange={(value) =>
-							handleUpdateConfig({ tabSize: Number(value) })
+							settingsStore.updateSettingByPath(
+								"tabSize",
+								Number(value)
+							)
 						}
 					/>
 				</SettingsItem>
@@ -453,15 +493,15 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					desc={t("setting.wrap.desc")}
 				>
 					<Toggle
-						checked={settingsValue.wrap}
+						checked={settings.wrap}
 						onChange={(value) =>
-							handleUpdateConfig({ wrap: value })
+							settingsStore.updateSettingByPath("wrap", value)
 						}
 					/>
 				</SettingsItem>
 			</>
 		);
-	}, [settingsValue, handleUpdateConfig]);
+	}, [settings]);
 
 	const ExtendSettings = React.useMemo(() => {
 		return (
@@ -471,26 +511,28 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 					desc={t("setting.snippetsManager.desc")}
 				>
 					<Toggle
-						checked={settingsValue.snippetsManager.location}
+						checked={settings.snippetsManager.location}
 						onChange={(value) =>
-							handleUpdateConfig({
-								snippetsManager: {
-									...settingsValue.snippetsManager,
+							settingsStore.updateSettingByPath(
+								"snippetsManager",
+								{
+									...settings.snippetsManager,
 									location: value,
-								},
-							})
+								}
+							)
 						}
 					/>
 					<IconPicker
-						app={plugin.app}
-						value={settingsValue.snippetsManager.icon}
+						app={app}
+						value={settings.snippetsManager.icon}
 						onChange={(value) =>
-							handleUpdateConfig({
-								snippetsManager: {
-									...settingsValue.snippetsManager,
+							settingsStore.updateSettingByPath(
+								"snippetsManager",
+								{
+									...settings.snippetsManager,
 									icon: value,
-								},
-							})
+								}
+							)
 						}
 					/>
 				</SettingsItem>
@@ -501,17 +543,18 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 				>
 					<Input
 						type="number"
-						value={settingsValue.embedMaxHeight}
+						value={settings.embedMaxHeight}
 						onChange={(value) =>
-							handleUpdateConfig({
-								embedMaxHeight: Number(value),
-							})
+							settingsStore.updateSettingByPath(
+								"embedMaxHeight",
+								Number(value)
+							)
 						}
 					/>
 				</SettingsItem>
 			</>
 		);
-	}, [settingsValue, handleUpdateConfig, plugin.app]);
+	}, [settings, app]);
 
 	const AboutSettings = React.useMemo(() => {
 		return (

--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -1,0 +1,132 @@
+import AceCodeEditorPlugin from "../main";
+import { DEFAULT_CONFIG, ICodeEditorConfig } from "../type/types";
+
+export default class SettingsStore {
+	#plugin: AceCodeEditorPlugin;
+	#subscribers = new Set<() => void>();
+
+	#store = {
+		subscribe: (callback: () => void) => {
+			this.#subscribers.add(callback);
+			return () => this.#subscribers.delete(callback);
+		},
+		getSnapshot: (): ICodeEditorConfig => this.#plugin.settings,
+	};
+
+	constructor(plugin: AceCodeEditorPlugin) {
+		this.#plugin = plugin;
+	}
+
+	get settings() {
+		return this.#plugin.settings;
+	}
+
+	get store() {
+		return Object.assign({}, this.#store);
+	}
+
+	get plugin() {
+		return this.#plugin;
+	}
+
+	get app() {
+		return this.#plugin.app;
+	}
+
+	#notifyStoreSubscribers() {
+		this.#subscribers.forEach((callback) => callback());
+	}
+
+	#mergeWithDefaults<T>(saved: unknown, defaults: T): T {
+		// 如果默认值是对象（且非数组），则递归按默认结构构建结果
+		if (
+			defaults !== null &&
+			typeof defaults === "object" &&
+			!Array.isArray(defaults)
+		) {
+			const result: Record<string, unknown> = {};
+			const defaultRecord = defaults as unknown as Record<
+				string,
+				unknown
+			>;
+			const savedRecord = (saved ?? {}) as Record<string, unknown>;
+			for (const key of Object.keys(defaultRecord)) {
+				result[key] = this.#mergeWithDefaults(
+					savedRecord[key],
+					defaultRecord[key]
+				);
+			}
+			return result as unknown as T;
+		}
+
+		// 基元或数组：类型不匹配或未提供则回退到默认值
+		const isArrayDefault = Array.isArray(defaults as unknown);
+		const isArraySaved = Array.isArray(saved as unknown);
+		if (
+			saved === undefined ||
+			(typeof defaults !== typeof saved && !isArrayDefault) ||
+			(isArrayDefault && !isArraySaved)
+		) {
+			return defaults;
+		}
+		return saved as T;
+	}
+
+	async loadSettings() {
+		const saved = await this.#plugin.loadData();
+		// 与默认配置深度对齐：只保留定义内字段并填充缺省
+		this.#plugin.settings = this.#mergeWithDefaults(
+			saved ?? {},
+			DEFAULT_CONFIG
+		);
+		await this.#plugin.saveSettings();
+		this.#notifyStoreSubscribers();
+	}
+
+	async updateSettings(settings: ICodeEditorConfig) {
+		this.#plugin.settings = Object.assign({}, settings);
+		await this.#plugin.saveSettings();
+		this.#notifyStoreSubscribers();
+	}
+
+	/**
+	 * 通过路径更新特定设置值
+	 * @param path 设置路径
+	 * @param value 新的设置值
+	 */
+	async updateSettingByPath<T>(path: string, value: T) {
+		// 创建设置的深拷贝
+		const newSettings = JSON.parse(JSON.stringify(this.#plugin.settings));
+		const pathParts = path.split(".");
+		let current: unknown = newSettings;
+
+		// 遍历路径，找到父对象
+		for (let i = 0; i < pathParts.length - 1; i++) {
+			const part = pathParts[i];
+			if (
+				typeof current === "object" &&
+				current !== null &&
+				part in current
+			) {
+				current = (current as Record<string, unknown>)[part];
+			} else {
+				throw new Error(`Invalid setting path: ${path}`);
+			}
+		}
+
+		// 设置最终值
+		const finalPart = pathParts[pathParts.length - 1];
+		if (
+			typeof current === "object" &&
+			current !== null &&
+			finalPart in current
+		) {
+			(current as Record<string, unknown>)[finalPart] = value;
+		} else {
+			throw new Error(`Invalid setting path: ${path}`);
+		}
+
+		// 使用 updateSettings 方法更新设置
+		await this.updateSettings(newSettings);
+	}
+}

--- a/src/settings/SettingsTab.tsx
+++ b/src/settings/SettingsTab.tsx
@@ -2,6 +2,7 @@ import AceCodeEditorPlugin from "@/src/main";
 import { App, PluginSettingTab } from "obsidian";
 import * as React from "react";
 import { createRoot, Root } from "react-dom/client";
+import { SettingsStoreContext } from "../context/SettingsStoreContext";
 import { AceSettings } from "./AceSettings";
 
 export default class AceCodeEditorSettingTab extends PluginSettingTab {
@@ -35,7 +36,11 @@ export default class AceCodeEditorSettingTab extends PluginSettingTab {
 	private renderContent() {
 		this.root?.render(
 			<React.StrictMode>
-				<AceSettings plugin={this.plugin} />
+				<SettingsStoreContext.Provider
+					value={this.plugin.settingsStore}
+				>
+					<AceSettings plugin={this.plugin} />
+				</SettingsStoreContext.Provider>
 			</React.StrictMode>
 		);
 	}


### PR DESCRIPTION
在插件中添加集中化的设置存储与订阅支持，以便 React 组件以稳定
且响应式的方式读取和更新配置。

主要变更：
- 添加 SettingsStore 类（src/settings/SettingsStore.ts）
  - 持有对插件实例的引用，暴露 settings 和 store 用于订阅/快照
  - 提供 loadSettings、updateSettings、updateSettingByPath 等方法
  - 在加载设置时与 DEFAULT_CONFIG 深度合并以保证字段和默认值一致
  - 在更新时通知所有订阅者，便于 UI 自动刷新
- 在插件主类中实例化 SettingsStore（src/main.ts）
  - 将 settingsStore 作为只读属性注入插件生命周期内使用
- 为 React 提供上下文（src/context/SettingsStoreContext.tsx）
  - 通过 Context 让组件树获取 SettingsStore 实例
- 在设置面板渲染处提供 Context（src/settings/SettingsTab.tsx）
  - 使用 SettingsStoreContext.Provider 包裹 AceSettings，避免逐层传参
- 新增 usePluginSettings Hook（src/hooks/usePluginSettings.tsx）
  - 基于 useSyncExternalStore 从 SettingsStore 的 store 读取快照并订阅变化
  - 返回类型化的 ICodeEditorConfig，便于组件使用

为何做这些改动：
- 将设置管理从零散的调用集中化，简化组件间的状态共享與同步逻辑。
- 使用订阅/快照模式兼容 React 的并发特性，提升渲染一致性和性能。
- 深度合并默认配置以避免丢失字段并确保向后兼容。