### PR TITLE
fix: 正确移除文件名中的 .css 扩展名

### DIFF
--- a/src/component/modal/SnippetsFileModal.tsx
+++ b/src/component/modal/SnippetsFileModal.tsx
@@ -64,7 +64,9 @@ const SnippetsFileModal: React.FC<SnippetsFileModalProps> = ({ onClose }) => {
 				.filter((file) => file.endsWith(".css"))
 				.map(async (file) => {
 					const fileName = file.split("/").pop() || file;
-					const fileNameWithoutExtension = fileName.split(".")[0];
+					const fileNameWithoutExtension = fileName.endsWith(".css")
+						? fileName.slice(0, -4)
+						: fileName;
 					const stat = await adapter.stat(file);
 					const isEnabled = app.customCss.enabledSnippets.has(
 						fileNameWithoutExtension
@@ -88,7 +90,9 @@ const SnippetsFileModal: React.FC<SnippetsFileModalProps> = ({ onClose }) => {
 	};
 
 	const handleToggleSnippet = async (fileName: string, checked: boolean) => {
-		const fileNameWithoutExtension = fileName.split(".")[0];
+		const fileNameWithoutExtension = fileName.endsWith(".css")
+			? fileName.slice(0, -4)
+			: fileName;
 		app.customCss.setCssEnabledStatus(fileNameWithoutExtension, checked);
 
 		requestLoadSnippets();


### PR DESCRIPTION
将从文件路径或文件名中提取无扩展名的逻辑由按点分割改为专门
处理 .css 后缀。以前使用 fileName.split(".")[0] 会在文件名包含点
(例如 my.snippet.css) 时错误截断，导致启用/禁用和状态判断使用了错
误的标识。现在通过检查 fileName 是否以 ".css" 结尾并切除最后四
个字符，保证获得完整的文件主体名。

此更改修复了对带有点的文件名处理错误，确保 app.customCss 的
启用状态与实际 snippet 文件对应，从而避免错配和无法正确切换
snippet 的问题。