### PR TITLE
refactor(settings): 简化 AceSettings 组件接口与状态管理

### DIFF
--- a/src/settings/AceSettings.tsx
+++ b/src/settings/AceSettings.tsx
@@ -7,7 +7,6 @@ import { Toggle } from "@src/component/toggle/Toggle";
 import usePluginSettings from "@src/hooks/usePluginSettings";
 import useSettingsStore from "@src/hooks/useSettingsStore";
 import { t } from "@src/i18n/i18n";
-import AceCodeEditorPlugin from "@src/main";
 import { languageModeMap } from "@src/service/AceLanguages";
 import {
 	AceDarkThemesList,
@@ -33,20 +32,12 @@ declare global {
 	}
 }
 
-interface AceSettingsProps {
-	plugin: AceCodeEditorPlugin;
-}
+interface AceSettingsProps {}
 
-export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
-	// const [settingsValue, setSettingsValue] = React.useState(plugin.settings);
+export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 	const settingsStore = useSettingsStore();
 	const settings = usePluginSettings(settingsStore);
 	const app = settingsStore.app;
-
-	// 监听外部settings变化，同步到本地状态
-	// React.useEffect(() => {
-	// 	setSettingsValue(plugin.settings);
-	// }, [plugin.settings]);
 
 	const [systemFonts, setSystemFonts] = React.useState<string[]>([]);
 
@@ -234,16 +225,6 @@ export const AceSettings: React.FC<AceSettingsProps> = ({ plugin }) => {
 			}
 		});
 	}
-
-	// const handleUpdateConfig = React.useCallback(
-	// 	async (newSettings: Partial<ICodeEditorConfig>) => {
-	// 		const updatedSettings = { ...settingsValue, ...newSettings };
-	// 		setSettingsValue(updatedSettings);
-	// 		// 直接调用plugin.updateSettings，避免useEffect带来的副作用
-	// 		await plugin.updateSettings(newSettings);
-	// 	},
-	// 	[settingsValue, plugin]
-	// );
 
 	const lightThemeOptions = React.useMemo(
 		() =>

--- a/src/settings/SettingsTab.tsx
+++ b/src/settings/SettingsTab.tsx
@@ -39,7 +39,7 @@ export default class AceCodeEditorSettingTab extends PluginSettingTab {
 				<SettingsStoreContext.Provider
 					value={this.plugin.settingsStore}
 				>
-					<AceSettings plugin={this.plugin} />
+					<AceSettings />
 				</SettingsStoreContext.Provider>
 			</React.StrictMode>
 		);


### PR DESCRIPTION
将 AceSettings 的 props 和内部对外部 plugin 的直接依赖移除，改为
不接受 plugin 参数，仅通过 SettingsStore 和自定义 hook 获取设置。
删除与 plugin.settings 绑定的本地状态和相关注释掉的同步/更新逻辑，
避免在组件内维护冗余的副本和通过副作用调用 plugin 更新，简化数据流。
同时更新 SettingsTab 的调用处，改为直接渲染 <AceSettings />。

这样做的目的是减少组件之间的耦合，统一通过 settingsStore 和 hook 管理设
置状态，降低副作用产生的风险并提升可维护性。