### PR TITLE
docs: 更新资助链接为 afdian

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -58,7 +58,7 @@
 - [查看贡献指南](./CONTRIBUTING.md) 如果你想为项目做出贡献
 
 如果你觉得这个插件对你有帮助，可以通过以下方式支持开发：
-- 微信/支付宝：[二维码](https://s2.loli.net/2024/05/06/lWBj3ObszUXSV2f.png)
+- [爱发电](https://afdian.com/a/ravenhogwarts)
 
 ## 许可证
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you encounter any issues or have suggestions:
 - [Check the contributing guidelines](./CONTRIBUTING.md) if you'd like to contribute to the project
 
 If you find this plugin helpful, you can support the development through:
-- WeChat/Alipay: [QR Code](https://s2.loli.net/2024/05/06/lWBj3ObszUXSV2f.png)
+- [afdian](https://afdian.com/a/ravenhogwarts)
 
 ## License
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -7,7 +7,7 @@
 	"author": "RavenHogWarts",
 	"authorUrl": "https://github.com/RavenHogWarts",
 	"fundingUrl": {
-		"微信/支付宝": "https://s2.loli.net/2024/05/06/lWBj3ObszUXSV2f.png"
+		"afdian": "https://afdian.com/a/ravenhogwarts"
 	},
 	"isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 	"author": "RavenHogWarts",
 	"authorUrl": "https://github.com/RavenHogWarts",
 	"fundingUrl": {
-		"微信/支付宝": "https://s2.loli.net/2024/05/06/lWBj3ObszUXSV2f.png"
+		"afdian": "https://afdian.com/a/ravenhogwarts"
 	},
 	"isDesktopOnly": false
 }


### PR DESCRIPTION
将原先在 manifest 和 README 中指向的微信/支付宝二维码链接
替换为作者的 afdian 页面链接。主要文件包括 manifest.json、
manifest-beta.json、README.md 和 README-zh.md。

这样做是为了统一并指向更稳定的资助平台，避免外部图床
或临时二维码链接失效，提升链接的可维护性和可访问性。