### PR TITLE
chore(deps): 升级若干依赖以修复问题并保持兼容

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,26 +10,26 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/ace": "^0.0.52",
-				"ace-builds": "^1.43.4",
+				"ace-builds": "^1.43.5",
 				"dotenv": "^17.2.3",
-				"html-react-parser": "^5.2.8",
-				"lucide-react": "^0.552.0",
+				"html-react-parser": "^5.2.10",
+				"lucide-react": "^0.556.0",
 				"radix-ui": "^1.4.3",
-				"react": "^19.2.0",
+				"react": "^19.2.1",
 				"react-ace": "^14.0.1",
-				"react-dom": "^19.2.0"
+				"react-dom": "^19.2.1"
 			},
 			"devDependencies": {
-				"@types/node": "^24.10.0",
-				"@types/react": "^19.2.2",
-				"@types/react-dom": "^19.2.2",
-				"@typescript-eslint/eslint-plugin": "8.46.3",
-				"@typescript-eslint/parser": "^8.46.3",
+				"@types/node": "^24.10.2",
+				"@types/react": "^19.2.7",
+				"@types/react-dom": "^19.2.3",
+				"@typescript-eslint/eslint-plugin": "8.49.0",
+				"@typescript-eslint/parser": "^8.49.0",
 				"builtin-modules": "5.0.0",
 				"conventional-changelog-cli": "^5.0.0",
-				"esbuild": "0.25.12",
+				"esbuild": "0.27.1",
 				"eslint": "^9.39.1",
-				"eslint-plugin-obsidianmd": "^0.1.8",
+				"eslint-plugin-obsidianmd": "^0.1.9",
 				"fs-extra": "^11.3.2",
 				"obsidian": "latest",
 				"postcss": "^8.5.6",
@@ -57,9 +57,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -67,9 +67,9 @@
 			}
 		},
 		"node_modules/@codemirror/state": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmmirror.com/@codemirror/state/-/state-6.5.2.tgz",
-			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmmirror.com/@codemirror/state/-/state-6.5.0.tgz",
+			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -78,9 +78,9 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.37.1",
-			"resolved": "https://registry.npmmirror.com/@codemirror/view/-/view-6.37.1.tgz",
-			"integrity": "sha512-Qy4CAUwngy/VQkEz0XzMKVRcckQuqLYWKqVpDDDghBe5FSXSqfVrJn49nw3ePZHxRUz4nRmb05Lgi+9csWo4eg==",
+			"version": "6.38.6",
+			"resolved": "https://registry.npmmirror.com/@codemirror/view/-/view-6.38.6.tgz",
+			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -164,9 +164,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+			"integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -181,9 +181,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+			"integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
 			"cpu": [
 				"arm"
 			],
@@ -198,9 +198,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+			"integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -215,9 +215,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+			"integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
 			"cpu": [
 				"x64"
 			],
@@ -232,9 +232,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-			"integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+			"integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -249,9 +249,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+			"integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
 			"cpu": [
 				"x64"
 			],
@@ -266,9 +266,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+			"integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
 			"cpu": [
 				"arm64"
 			],
@@ -283,9 +283,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+			"integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
 			"cpu": [
 				"x64"
 			],
@@ -300,9 +300,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+			"integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
 			"cpu": [
 				"arm"
 			],
@@ -317,9 +317,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+			"integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -334,9 +334,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+			"integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
 			"cpu": [
 				"ia32"
 			],
@@ -351,9 +351,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+			"integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
 			"cpu": [
 				"loong64"
 			],
@@ -368,9 +368,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+			"integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -385,9 +385,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+			"integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -402,9 +402,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+			"integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -419,9 +419,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+			"integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
 			"cpu": [
 				"s390x"
 			],
@@ -436,9 +436,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+			"integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
 			"cpu": [
 				"x64"
 			],
@@ -453,9 +453,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+			"integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -470,9 +470,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+			"integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
 			"cpu": [
 				"x64"
 			],
@@ -487,9 +487,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+			"integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
 			"cpu": [
 				"arm64"
 			],
@@ -504,9 +504,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+			"integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
 			"cpu": [
 				"x64"
 			],
@@ -521,9 +521,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+			"integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -538,9 +538,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+			"integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
 			"cpu": [
 				"x64"
 			],
@@ -555,9 +555,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+			"integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
 			"cpu": [
 				"arm64"
 			],
@@ -572,9 +572,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+			"integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -589,9 +589,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+			"integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
 			"cpu": [
 				"x64"
 			],
@@ -700,9 +700,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -712,7 +712,7 @@
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
+				"js-yaml": "^4.1.1",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -734,6 +734,16 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
@@ -753,12 +763,28 @@
 			"integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
+			}
+		},
+		"node_modules/@eslint/json": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmmirror.com/@eslint/json/-/json-0.14.0.tgz",
+			"integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/core": "^0.17.0",
+				"@eslint/plugin-kit": "^0.4.1",
+				"@humanwhocodes/momoa": "^3.3.10",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
@@ -861,6 +887,17 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@humanwhocodes/momoa": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmmirror.com/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
+			"integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmmirror.com/@humanwhocodes/retry/-/retry-0.4.3.tgz",
@@ -890,7 +927,8 @@
 			"resolved": "https://registry.npmmirror.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@microsoft/eslint-plugin-sdl": {
 			"version": "1.1.0",
@@ -928,44 +966,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"ret": "~0.1.10"
-			}
-		},
-		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/@pkgr/core": {
@@ -2535,9 +2535,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.10.0",
-			"resolved": "https://registry.npmmirror.com/@types/node/-/node-24.10.0.tgz",
-			"integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+			"version": "24.10.2",
+			"resolved": "https://registry.npmmirror.com/@types/node/-/node-24.10.2.tgz",
+			"integrity": "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2552,31 +2552,29 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.2",
-			"resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.2.tgz",
-			"integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.7.tgz",
+			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "19.2.2",
-			"resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.2.tgz",
-			"integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
+			"version": "19.2.3",
+			"resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.3.tgz",
+			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
 		},
 		"node_modules/@types/semver": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmmirror.com/@types/semver/-/semver-7.7.0.tgz",
-			"integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmmirror.com/@types/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2591,18 +2589,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.3.tgz",
-			"integrity": "sha512-sbaQ27XBUopBkRiuY/P9sWGOWUW4rl8fDoHIUmLpZd8uldsTyB4/Zg6bWTegPoTLnKj9Hqgn3QD6cjPNB32Odw==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
+			"integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.46.3",
-				"@typescript-eslint/type-utils": "8.46.3",
-				"@typescript-eslint/utils": "8.46.3",
-				"@typescript-eslint/visitor-keys": "8.46.3",
-				"graphemer": "^1.4.0",
+				"@typescript-eslint/scope-manager": "8.49.0",
+				"@typescript-eslint/type-utils": "8.49.0",
+				"@typescript-eslint/utils": "8.49.0",
+				"@typescript-eslint/visitor-keys": "8.49.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.1.0"
@@ -2615,33 +2612,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.46.3",
+				"@typescript-eslint/parser": "^8.49.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmmirror.com/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-8.46.3.tgz",
-			"integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-8.49.0.tgz",
+			"integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.46.3",
-				"@typescript-eslint/types": "8.46.3",
-				"@typescript-eslint/typescript-estree": "8.46.3",
-				"@typescript-eslint/visitor-keys": "8.46.3",
+				"@typescript-eslint/scope-manager": "8.49.0",
+				"@typescript-eslint/types": "8.49.0",
+				"@typescript-eslint/typescript-estree": "8.49.0",
+				"@typescript-eslint/visitor-keys": "8.49.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2657,14 +2643,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/project-service/-/project-service-8.46.3.tgz",
-			"integrity": "sha512-Fz8yFXsp2wDFeUElO88S9n4w1I4CWDTXDqDr9gYvZgUpwXQqmZBr9+NTTql5R3J7+hrJZPdpiWaB9VNhAKYLuQ==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+			"integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.46.3",
-				"@typescript-eslint/types": "^8.46.3",
+				"@typescript-eslint/tsconfig-utils": "^8.49.0",
+				"@typescript-eslint/types": "^8.49.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2679,14 +2665,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-8.46.3.tgz",
-			"integrity": "sha512-FCi7Y1zgrmxp3DfWfr+3m9ansUUFoy8dkEdeQSgA9gbm8DaHYvZCdkFRQrtKiedFf3Ha6VmoqoAaP68+i+22kg==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
+			"integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.3",
-				"@typescript-eslint/visitor-keys": "8.46.3"
+				"@typescript-eslint/types": "8.49.0",
+				"@typescript-eslint/visitor-keys": "8.49.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2697,9 +2683,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.3.tgz",
-			"integrity": "sha512-GLupljMniHNIROP0zE7nCcybptolcH8QZfXOpCfhQDAdwJ/ZTlcaBOYebSOZotpti/3HrHSw7D3PZm75gYFsOA==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+			"integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2714,15 +2700,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-8.46.3.tgz",
-			"integrity": "sha512-ZPCADbr+qfz3aiTTYNNkCbUt+cjNwI/5McyANNrFBpVxPt7GqpEYz5ZfdwuFyGUnJ9FdDXbGODUu6iRCI6XRXw==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
+			"integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.3",
-				"@typescript-eslint/typescript-estree": "8.46.3",
-				"@typescript-eslint/utils": "8.46.3",
+				"@typescript-eslint/types": "8.49.0",
+				"@typescript-eslint/typescript-estree": "8.49.0",
+				"@typescript-eslint/utils": "8.49.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -2739,9 +2725,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.46.3.tgz",
-			"integrity": "sha512-G7Ok9WN/ggW7e/tOf8TQYMaxgID3Iujn231hfi0Pc7ZheztIJVpO44ekY00b7akqc6nZcvregk0Jpah3kep6hA==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.49.0.tgz",
+			"integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2753,21 +2739,20 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.3.tgz",
-			"integrity": "sha512-f/NvtRjOm80BtNM5OQtlaBdM5BRFUv7gf381j9wygDNL+qOYSNOgtQ/DCndiYi80iIOv76QqaTmp4fa9hwI0OA==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
+			"integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.46.3",
-				"@typescript-eslint/tsconfig-utils": "8.46.3",
-				"@typescript-eslint/types": "8.46.3",
-				"@typescript-eslint/visitor-keys": "8.46.3",
+				"@typescript-eslint/project-service": "8.49.0",
+				"@typescript-eslint/tsconfig-utils": "8.49.0",
+				"@typescript-eslint/types": "8.49.0",
+				"@typescript-eslint/visitor-keys": "8.49.0",
 				"debug": "^4.3.4",
-				"fast-glob": "^3.3.2",
-				"is-glob": "^4.0.3",
 				"minimatch": "^9.0.4",
 				"semver": "^7.6.0",
+				"tinyglobby": "^0.2.15",
 				"ts-api-utils": "^2.1.0"
 			},
 			"engines": {
@@ -2782,16 +2767,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-8.46.3.tgz",
-			"integrity": "sha512-VXw7qmdkucEx9WkmR3ld/u6VhRyKeiF1uxWwCy/iuNfokjJ7VhsgLSOTjsol8BunSw190zABzpwdNsze2Kpo4g==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-8.49.0.tgz",
+			"integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.46.3",
-				"@typescript-eslint/types": "8.46.3",
-				"@typescript-eslint/typescript-estree": "8.46.3"
+				"@typescript-eslint/scope-manager": "8.49.0",
+				"@typescript-eslint/types": "8.49.0",
+				"@typescript-eslint/typescript-estree": "8.49.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2806,13 +2791,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.3.tgz",
-			"integrity": "sha512-uk574k8IU0rOF/AjniX8qbLSGURJVUCeM5e4MIMKBFFi8weeiLrG1fyQejyLXQpRZbU/1BuQasleV/RfHC3hHg==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
+			"integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.3",
+				"@typescript-eslint/types": "8.49.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -2837,9 +2822,9 @@
 			}
 		},
 		"node_modules/ace-builds": {
-			"version": "1.43.4",
-			"resolved": "https://registry.npmmirror.com/ace-builds/-/ace-builds-1.43.4.tgz",
-			"integrity": "sha512-8hAxVfo2ImICd69BWlZwZlxe9rxDGDjuUhh+WeWgGDvfBCE+r3lkynkQvIovDz4jcMi8O7bsEaFygaDT+h9sBA==",
+			"version": "1.43.5",
+			"resolved": "https://registry.npmmirror.com/ace-builds/-/ace-builds-1.43.5.tgz",
+			"integrity": "sha512-iH5FLBKdB7SVn9GR37UgA/tpQS8OTWIxWAuq3Ofaw+Qbc69FfPXsXd9jeW7KRG2xKpKMqBDnu0tHBrCWY5QI7A==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/acorn": {
@@ -2848,7 +2833,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3135,19 +3119,6 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/builtin-modules": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/builtin-modules/-/builtin-modules-5.0.0.tgz",
@@ -3300,9 +3271,9 @@
 			}
 		},
 		"node_modules/conventional-changelog-angular": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
-			"integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmmirror.com/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
+			"integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3450,9 +3421,9 @@
 			}
 		},
 		"node_modules/conventional-changelog-writer": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmmirror.com/conventional-changelog-writer/-/conventional-changelog-writer-8.1.0.tgz",
-			"integrity": "sha512-dpC440QnORNCO81XYuRRFOLCsjKj4W7tMkUIn3lR6F/FAaJcWLi7iCj6IcEvSQY2zw6VUgwUKd5DEHKEWrpmEQ==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmmirror.com/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
+			"integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3479,12 +3450,11 @@
 			}
 		},
 		"node_modules/conventional-commits-parser": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmmirror.com/conventional-commits-parser/-/conventional-commits-parser-6.2.0.tgz",
-			"integrity": "sha512-uLnoLeIW4XaoFtH37qEcg/SXMJmKF4vi7V0H2rnPueg+VEtFGA/asSCNTcq4M/GQ6QmlzchAEtOoDTtKqWeHag==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmmirror.com/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
+			"integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"meow": "^13.0.0"
 			},
@@ -3500,7 +3470,8 @@
 			"resolved": "https://registry.npmmirror.com/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -3531,9 +3502,9 @@
 			}
 		},
 		"node_modules/csstype": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"devOptional": true,
 			"license": "MIT"
 		},
@@ -3784,6 +3755,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/empathic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmmirror.com/empathic/-/empathic-2.0.0.tgz",
+			"integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.3",
 			"resolved": "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -3988,9 +3969,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.25.12.tgz",
-			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+			"version": "0.27.1",
+			"resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.27.1.tgz",
+			"integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -4001,32 +3982,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.12",
-				"@esbuild/android-arm": "0.25.12",
-				"@esbuild/android-arm64": "0.25.12",
-				"@esbuild/android-x64": "0.25.12",
-				"@esbuild/darwin-arm64": "0.25.12",
-				"@esbuild/darwin-x64": "0.25.12",
-				"@esbuild/freebsd-arm64": "0.25.12",
-				"@esbuild/freebsd-x64": "0.25.12",
-				"@esbuild/linux-arm": "0.25.12",
-				"@esbuild/linux-arm64": "0.25.12",
-				"@esbuild/linux-ia32": "0.25.12",
-				"@esbuild/linux-loong64": "0.25.12",
-				"@esbuild/linux-mips64el": "0.25.12",
-				"@esbuild/linux-ppc64": "0.25.12",
-				"@esbuild/linux-riscv64": "0.25.12",
-				"@esbuild/linux-s390x": "0.25.12",
-				"@esbuild/linux-x64": "0.25.12",
-				"@esbuild/netbsd-arm64": "0.25.12",
-				"@esbuild/netbsd-x64": "0.25.12",
-				"@esbuild/openbsd-arm64": "0.25.12",
-				"@esbuild/openbsd-x64": "0.25.12",
-				"@esbuild/openharmony-arm64": "0.25.12",
-				"@esbuild/sunos-x64": "0.25.12",
-				"@esbuild/win32-arm64": "0.25.12",
-				"@esbuild/win32-ia32": "0.25.12",
-				"@esbuild/win32-x64": "0.25.12"
+				"@esbuild/aix-ppc64": "0.27.1",
+				"@esbuild/android-arm": "0.27.1",
+				"@esbuild/android-arm64": "0.27.1",
+				"@esbuild/android-x64": "0.27.1",
+				"@esbuild/darwin-arm64": "0.27.1",
+				"@esbuild/darwin-x64": "0.27.1",
+				"@esbuild/freebsd-arm64": "0.27.1",
+				"@esbuild/freebsd-x64": "0.27.1",
+				"@esbuild/linux-arm": "0.27.1",
+				"@esbuild/linux-arm64": "0.27.1",
+				"@esbuild/linux-ia32": "0.27.1",
+				"@esbuild/linux-loong64": "0.27.1",
+				"@esbuild/linux-mips64el": "0.27.1",
+				"@esbuild/linux-ppc64": "0.27.1",
+				"@esbuild/linux-riscv64": "0.27.1",
+				"@esbuild/linux-s390x": "0.27.1",
+				"@esbuild/linux-x64": "0.27.1",
+				"@esbuild/netbsd-arm64": "0.27.1",
+				"@esbuild/netbsd-x64": "0.27.1",
+				"@esbuild/openbsd-arm64": "0.27.1",
+				"@esbuild/openbsd-x64": "0.27.1",
+				"@esbuild/openharmony-arm64": "0.27.1",
+				"@esbuild/sunos-x64": "0.27.1",
+				"@esbuild/win32-arm64": "0.27.1",
+				"@esbuild/win32-ia32": "0.27.1",
+				"@esbuild/win32-x64": "0.27.1"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -4048,7 +4029,6 @@
 			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -4167,6 +4147,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-depend": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmmirror.com/eslint-plugin-depend/-/eslint-plugin-depend-1.3.1.tgz",
+			"integrity": "sha512-1uo2rFAr9vzNrCYdp7IBZRB54LiyVxfaIso0R6/QV3t6Dax6DTbW/EV2Hktf0f4UtmGHK8UyzJWI382pwW04jw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"empathic": "^2.0.0",
+				"module-replacements": "^2.8.0",
+				"semver": "^7.6.3"
 			}
 		},
 		"node_modules/eslint-plugin-es-x": {
@@ -4377,10 +4369,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/eslint-plugin-n/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/eslint-plugin-obsidianmd": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmmirror.com/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.1.8.tgz",
-			"integrity": "sha512-3hkIgpr/XHIKFIE0ucU2bVnwESLzLzgNehTX5fZtiXeWNZ7U1hheIhfwye+R1FK4FqhxA1pZ33o1a67eIDKDlw==",
+			"version": "0.1.9",
+			"resolved": "https://registry.npmmirror.com/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.1.9.tgz",
+			"integrity": "sha512-/gyo5vky3Y7re4BtT/8MQbHU5Wes4o6VRqas3YmXE7aTCnMsdV0kfzV1GDXJN9Hrsc9UQPoeKUMiapKL0aGE4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4388,10 +4390,12 @@
 				"@types/eslint": "8.56.2",
 				"@types/node": "20.12.12",
 				"eslint": ">=9.0.0 <10.0.0",
+				"eslint-plugin-depend": "1.3.1",
 				"eslint-plugin-import": "^2.31.0",
 				"eslint-plugin-json-schema-validator": "5.1.0",
 				"eslint-plugin-security": "2.1.1",
 				"globals": "14.0.0",
+				"obsidian": "1.8.7",
 				"typescript": "5.4.5"
 			},
 			"bin": {
@@ -4402,7 +4406,9 @@
 			},
 			"peerDependencies": {
 				"@eslint/js": "^9.30.1",
+				"@eslint/json": "0.14.0",
 				"eslint": ">=9.0.0 <10.0.0",
+				"obsidian": "1.8.7",
 				"typescript-eslint": "^8.35.1"
 			}
 		},
@@ -4414,6 +4420,21 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/obsidian": {
+			"version": "1.8.7",
+			"resolved": "https://registry.npmmirror.com/obsidian/-/obsidian-1.8.7.tgz",
+			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/codemirror": "5.60.8",
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/typescript": {
@@ -4586,6 +4607,16 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/eslint/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
@@ -4683,36 +4714,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/fast-glob/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4744,14 +4745,22 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmmirror.com/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
 			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"reusify": "^1.0.4"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -4765,19 +4774,6 @@
 			},
 			"engines": {
 				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/find-up": {
@@ -5089,13 +5085,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/graphemer": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmmirror.com/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/handlebars": {
 			"version": "4.7.8",
 			"resolved": "https://registry.npmmirror.com/handlebars/-/handlebars-4.7.8.tgz",
@@ -5226,9 +5215,9 @@
 			}
 		},
 		"node_modules/html-dom-parser": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmmirror.com/html-dom-parser/-/html-dom-parser-5.1.1.tgz",
-			"integrity": "sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmmirror.com/html-dom-parser/-/html-dom-parser-5.1.2.tgz",
+			"integrity": "sha512-9nD3Rj3/FuQt83AgIa1Y3ruzspwFFA54AJbQnohXN+K6fL1/bhcDQJJY5Ne4L4A163ADQFVESd/0TLyNoV0mfg==",
 			"license": "MIT",
 			"dependencies": {
 				"domhandler": "5.0.3",
@@ -5236,15 +5225,15 @@
 			}
 		},
 		"node_modules/html-react-parser": {
-			"version": "5.2.8",
-			"resolved": "https://registry.npmmirror.com/html-react-parser/-/html-react-parser-5.2.8.tgz",
-			"integrity": "sha512-09WaI81tbpwhXWeMe1m9VptZVJUcigo0l59zVt+2HUIQT7+baU38/oNhllj6MKhOuGXqh0nrlwOgxbxbm6xXHw==",
+			"version": "5.2.10",
+			"resolved": "https://registry.npmmirror.com/html-react-parser/-/html-react-parser-5.2.10.tgz",
+			"integrity": "sha512-DjOLloguuDA+Ed7Q7PKhvMQmCl2+Yk/pfvvca68fvn15QFBbL4uHGxXwoXQ4sqS0UyuRH2lJb0S8yZCL3lvehQ==",
 			"license": "MIT",
 			"dependencies": {
 				"domhandler": "5.0.3",
-				"html-dom-parser": "5.1.1",
+				"html-dom-parser": "5.1.2",
 				"react-property": "2.0.2",
-				"style-to-js": "1.1.19"
+				"style-to-js": "1.1.21"
 			},
 			"peerDependencies": {
 				"@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
@@ -5276,9 +5265,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmmirror.com/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5313,9 +5302,9 @@
 			}
 		},
 		"node_modules/index-to-position": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmmirror.com/index-to-position/-/index-to-position-1.1.0.tgz",
-			"integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmmirror.com/index-to-position/-/index-to-position-1.2.0.tgz",
+			"integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5326,9 +5315,9 @@
 			}
 		},
 		"node_modules/inline-style-parser": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmmirror.com/inline-style-parser/-/inline-style-parser-0.2.6.tgz",
-			"integrity": "sha512-gtGXVaBdl5mAes3rPcMedEBm12ibjt1kDMFfheul1wUAOVEJW60voNdMVzVkfLN06O7ZaD/rxhfKgtlgtTbMjg==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmmirror.com/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
 			"license": "MIT"
 		},
 		"node_modules/internal-slot": {
@@ -5566,16 +5555,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/is-number-object": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmmirror.com/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -5787,9 +5766,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5868,9 +5847,9 @@
 			}
 		},
 		"node_modules/jsonc-eslint-parser": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmmirror.com/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.1.tgz",
-			"integrity": "sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmmirror.com/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+			"integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5905,9 +5884,9 @@
 			}
 		},
 		"node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6014,9 +5993,9 @@
 			"license": "ISC"
 		},
 		"node_modules/lucide-react": {
-			"version": "0.552.0",
-			"resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.552.0.tgz",
-			"integrity": "sha512-g9WCjmfwqbexSnZE+2cl21PCfXOcqnGeWeMTNAOGEfpPbm/ZF4YIq77Z8qWrxbu660EKuLB4nSLggoKnCb+isw==",
+			"version": "0.556.0",
+			"resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.556.0.tgz",
+			"integrity": "sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A==",
 			"license": "ISC",
 			"peerDependencies": {
 				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6045,30 +6024,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/merge2": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.5.tgz",
@@ -6086,14 +6041,21 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/module-replacements": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmmirror.com/module-replacements/-/module-replacements-2.10.1.tgz",
+			"integrity": "sha512-qkKuLpMHDqRSM676OPL7HUpCiiP3NSxgf8NNR1ga2h/iJLNKTsOSjMEwrcT85DMSti2vmOqxknOVBGWj6H6etQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/moment": {
 			"version": "2.29.4",
@@ -6283,9 +6245,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.8.7",
-			"resolved": "https://registry.npmmirror.com/obsidian/-/obsidian-1.8.7.tgz",
-			"integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmmirror.com/obsidian/-/obsidian-1.10.3.tgz",
+			"integrity": "sha512-VP+ZSxNMG7y6Z+sU9WqLvJAskCfkFrTz2kFHWmmzis+C+4+ELjk/sazwcTHrHXNZlgCeo8YOlM6SOrAFCynNew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6293,8 +6255,8 @@
 				"moment": "2.29.4"
 			},
 			"peerDependencies": {
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0"
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
 			}
 		},
 		"node_modules/optionator": {
@@ -6378,6 +6340,24 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
@@ -6413,13 +6393,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -6455,7 +6435,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -6494,12 +6473,11 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmmirror.com/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmmirror.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -6538,27 +6516,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/radix-ui": {
 			"version": "1.4.3",
@@ -6638,11 +6595,10 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "19.2.0",
-			"resolved": "https://registry.npmmirror.com/react/-/react-19.2.0.tgz",
-			"integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+			"version": "19.2.1",
+			"resolved": "https://registry.npmmirror.com/react/-/react-19.2.1.tgz",
+			"integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6665,16 +6621,15 @@
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.0",
-			"resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.0.tgz",
-			"integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+			"version": "19.2.1",
+			"resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.1.tgz",
+			"integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
 			"peerDependencies": {
-				"react": "^19.2.0"
+				"react": "^19.2.1"
 			}
 		},
 		"node_modules/react-is": {
@@ -6690,9 +6645,9 @@
 			"license": "MIT"
 		},
 		"node_modules/react-remove-scroll": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmmirror.com/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-			"integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+			"version": "2.7.2",
+			"resolved": "https://registry.npmmirror.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
 			"license": "MIT",
 			"dependencies": {
 				"react-remove-scroll-bar": "^2.3.7",
@@ -6776,19 +6731,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/read-package-up/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/read-pkg": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmmirror.com/read-pkg/-/read-pkg-9.0.1.tgz",
@@ -6804,37 +6746,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6955,41 +6866,6 @@
 				"node": ">=0.12"
 			}
 		},
-		"node_modules/reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmmirror.com/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/safe-array-concat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmmirror.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -7083,9 +6959,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7293,9 +7169,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmmirror.com/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+			"version": "3.0.22",
+			"resolved": "https://registry.npmmirror.com/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -7435,28 +7311,29 @@
 			}
 		},
 		"node_modules/style-mod": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmmirror.com/style-mod/-/style-mod-4.1.2.tgz",
-			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmmirror.com/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/style-to-js": {
-			"version": "1.1.19",
-			"resolved": "https://registry.npmmirror.com/style-to-js/-/style-to-js-1.1.19.tgz",
-			"integrity": "sha512-Ev+SgeqiNGT1ufsXyVC5RrJRXdrkRJ1Gol9Qw7Pb72YCKJXrBvP0ckZhBeVSrw2m06DJpei2528uIpjMb4TsoQ==",
+			"version": "1.1.21",
+			"resolved": "https://registry.npmmirror.com/style-to-js/-/style-to-js-1.1.21.tgz",
+			"integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
 			"license": "MIT",
 			"dependencies": {
-				"style-to-object": "1.0.12"
+				"style-to-object": "1.0.14"
 			}
 		},
 		"node_modules/style-to-object": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmmirror.com/style-to-object/-/style-to-object-1.0.12.tgz",
-			"integrity": "sha512-ddJqYnoT4t97QvN2C95bCgt+m7AAgXjVnkk/jxAfmp7EAB8nnqqZYEbMd3em7/vEomDb2LAQKAy1RFfv41mdNw==",
+			"version": "1.0.14",
+			"resolved": "https://registry.npmmirror.com/style-to-object/-/style-to-object-1.0.14.tgz",
+			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
 			"license": "MIT",
 			"dependencies": {
-				"inline-style-parser": "0.2.6"
+				"inline-style-parser": "0.2.7"
 			}
 		},
 		"node_modules/supports-color": {
@@ -7542,17 +7419,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-number": "^7.0.0"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
-				"node": ">=8.0"
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
 		"node_modules/toml-eslint-parser": {
@@ -7627,6 +7508,19 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/typed-array-buffer": {
@@ -7713,7 +7607,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7723,17 +7616,17 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.46.3",
-			"resolved": "https://registry.npmmirror.com/typescript-eslint/-/typescript-eslint-8.46.3.tgz",
-			"integrity": "sha512-bAfgMavTuGo+8n6/QQDVQz4tZ4f7Soqg53RbrlZQEoAltYop/XR4RAts/I0BrO3TTClTSTFJ0wYbla+P8cEWJA==",
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/typescript-eslint/-/typescript-eslint-8.49.0.tgz",
+			"integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.46.3",
-				"@typescript-eslint/parser": "8.46.3",
-				"@typescript-eslint/typescript-estree": "8.46.3",
-				"@typescript-eslint/utils": "8.46.3"
+				"@typescript-eslint/eslint-plugin": "8.49.0",
+				"@typescript-eslint/parser": "8.49.0",
+				"@typescript-eslint/typescript-estree": "8.49.0",
+				"@typescript-eslint/utils": "8.49.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7864,9 +7757,9 @@
 			}
 		},
 		"node_modules/use-sync-external-store": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-			"integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -7895,7 +7788,8 @@
 			"resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -8020,9 +7914,9 @@
 			"license": "MIT"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -8030,12 +7924,15 @@
 			},
 			"engines": {
 				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yaml-eslint-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmmirror.com/yaml-eslint-parser/-/yaml-eslint-parser-1.3.0.tgz",
-			"integrity": "sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmmirror.com/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
+			"integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
 		"node": ">=18.x"
 	},
 	"devDependencies": {
-		"@types/node": "^24.10.0",
-		"@types/react": "^19.2.2",
-		"@types/react-dom": "^19.2.2",
-		"@typescript-eslint/eslint-plugin": "8.46.3",
-		"@typescript-eslint/parser": "^8.46.3",
+		"@types/node": "^24.10.2",
+		"@types/react": "^19.2.7",
+		"@types/react-dom": "^19.2.3",
+		"@typescript-eslint/eslint-plugin": "8.49.0",
+		"@typescript-eslint/parser": "^8.49.0",
 		"builtin-modules": "5.0.0",
 		"conventional-changelog-cli": "^5.0.0",
-		"esbuild": "0.25.12",
+		"esbuild": "0.27.1",
 		"eslint": "^9.39.1",
-		"eslint-plugin-obsidianmd": "^0.1.8",
+		"eslint-plugin-obsidianmd": "^0.1.9",
 		"fs-extra": "^11.3.2",
 		"obsidian": "latest",
 		"postcss": "^8.5.6",
@@ -45,13 +45,13 @@
 	},
 	"dependencies": {
 		"@types/ace": "^0.0.52",
-		"ace-builds": "^1.43.4",
+		"ace-builds": "^1.43.5",
 		"dotenv": "^17.2.3",
-		"html-react-parser": "^5.2.8",
-		"lucide-react": "^0.552.0",
+		"html-react-parser": "^5.2.10",
+		"lucide-react": "^0.556.0",
 		"radix-ui": "^1.4.3",
-		"react": "^19.2.0",
+		"react": "^19.2.1",
 		"react-ace": "^14.0.1",
-		"react-dom": "^19.2.0"
+		"react-dom": "^19.2.1"
 	}
 }


### PR DESCRIPTION
更新 package.json 和 lockfile 中的多项依赖版本：
- 提升 TypeScript/ESLint 相关包（@typescript-eslint 插件/解析器）
  以获得最新规则和 bug 修复。
- 升级 @types/*、react、react-dom、ace-builds、html-react-parser、
  lucide-react 等运行时或类型依赖，保持与平台和第三方库的兼容。
- 升级 esbuild 与部分 node_modules 包以修复构建或安全相关问题。

为什么做这些改动：
- 修复已知的 bug 和安全隐患，确保构建工具和类型定义是最新的。
- 保持与 React/第三方库的兼容，减少运行时或类型检查错误。
- 使开发依赖与社区发布版本保持同步，便于未来维护和升级。