### PR TITLE
feat(minimap): 固定滑块高度并完善悬停和拖拽交互

### DIFF
--- a/styles/Minimap.css
+++ b/styles/Minimap.css
@@ -30,22 +30,30 @@
 	right: 0;
 	left: 0;
 	top: var(--minimap-slider-top, 0);
-	height: var(--minimap-slider-height, 100px);
+	height: 10dvh; /* 固定高度 */
 	background-color: var(--interactive-accent);
-	opacity: 0.2;
-	border: 2px solid var(--interactive-accent);
+	opacity: 0;
+	border: 1px solid var(--interactive-accent);
 	cursor: pointer;
 	pointer-events: all;
-	transition: opacity 0.15s ease-in-out;
+	transition: opacity 0.2s ease-in-out;
 	box-sizing: border-box;
+	border-radius: 3px;
 }
 
-.ace-minimap-slider:hover {
-	opacity: 0.35;
+/* 鼠标悬停在容器上时显示 slider */
+.ace-minimap-slider.visible {
+	opacity: 0.15;
 }
 
-.ace-minimap-slider:active {
-	opacity: 0.5;
+/* 鼠标悬停在 slider 上时加深 */
+.ace-minimap-slider.visible:hover {
+	opacity: 0.3;
+}
+
+/* 拖动时再次加深 */
+.ace-minimap-slider.dragging {
+	opacity: 0.4 !important;
 }
 
 /* 暗色主题调整 */


### PR DESCRIPTION
将 minimap 滑块改为固定高度并加入容器层级的悬停与拖拽状态，
以改善可见性和交互一致性。主要改动包括：

- 在组件中添加 containerRef、isHovering 和 isDragging 状态，
  并在容器上注册 onMouseEnter/onMouseLeave 以控制滑块显示。
- 在滑块按下时设置 isDragging 为 true，释放时重置为 false，
  防止拖拽过程中悬停状态被误清除。
- 移除基于可视行数计算的滑块高度，改用 CSS 中的固定高度
  (10dvh)，并只通过 CSS 变量更新滑块顶部位置，避免高度闪烁。
- 根据 isHovering 和 isDragging 动态添加类名以控制透明度和
  拖动样式，调整 CSS 动画时长、边框和圆角以提升视觉效果。

这些修改解决了滑块高度抖动、悬停触发不稳定以及拖拽时
可见性不足的问题，提升了 minimap 的使用体验。