### PR TITLE
feat(settings): 为设置页添加图标（ob 1.11.0）

### DIFF
--- a/src/settings/SettingsTab.tsx
+++ b/src/settings/SettingsTab.tsx
@@ -8,6 +8,7 @@ import { AceSettings } from "./AceSettings";
 export default class AceCodeEditorSettingTab extends PluginSettingTab {
 	plugin: AceCodeEditorPlugin;
 	root: Root | null = null;
+	icon: string = "square-dashed-bottom-code";
 
 	constructor(app: App, plugin: AceCodeEditorPlugin) {
 		super(app, plugin);


### PR DESCRIPTION
在 SettingsTab 类中新增 icon 字段并赋默认值 "square-dashed-bottom-code"。
通过在实例上显式存储图标标识符，便于后续在渲染设置选项或插件界面
时统一使用该图标，减少重复硬编码并提高可维护性。