### PR TITLE
fix(icon-picker): 移除多余的父类渲染调用

### DIFF
--- a/src/component/icon-picker/IconPicker.tsx
+++ b/src/component/icon-picker/IconPicker.tsx
@@ -68,7 +68,6 @@ class IconSelector extends FuzzySuggestModal<IconName> {
 	}
 
 	renderSuggestion(item: FuzzyMatch<IconName>, el: HTMLElement) {
-		super.renderSuggestion(item, el);
 		el.addClass("ace-icon-suggestion");
 		setIcon(el, item.item);
 		el.createSpan({ text: item.item });


### PR DESCRIPTION
删除 IconPicker.renderSuggestion 中对 super.renderSuggestion 的调用。
原实现会在建议项上重复渲染或添加不必要的 DOM/样式，导致建议项样式和内容
不符合预期。现在直接自行为建议元素设置类、图标和文本，避免重复渲染并简化
渲染流程，提高可控性和性能。