### PR TITLE
feat(minimap): 为小地图添加渲染与交互改进

### DIFF
--- a/src/view/Minimap.tsx
+++ b/src/view/Minimap.tsx
@@ -6,16 +6,39 @@ export interface MinimapProps {
 	enabled: boolean;
 }
 
+// 语法高亮颜色映射 (可根据你的编辑器主题调整)
+const TOKEN_COLORS: Record<string, string> = {
+	comment: "#6a9955", // 绿色
+	string: "#ce9178", // 橙红
+	constant: "#569cd6", // 蓝色
+	keyword: "#c586c0", // 紫色
+	default: "rgba(128, 128, 128, 0.5)", // 默认灰
+};
+
 export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 	const canvasRef = React.useRef<HTMLCanvasElement>(null);
 	const sliderRef = React.useRef<HTMLDivElement>(null);
 	const containerRef = React.useRef<HTMLDivElement>(null);
+
 	const [isHovering, setIsHovering] = React.useState(false);
 	const [isDragging, setIsDragging] = React.useState(false);
+	const isDraggingRef = React.useRef(false);
 
-	// 渲染 minimap 内容
+	const config = React.useMemo(
+		() => ({
+			lineHeight: 3, // Minimap 行高 (px)
+			charWidth: 2, // Minimap 字符宽 (px)
+			sliderRatio: 0.1, // 长文档模式下滑块占视口高度的比例 (0.1 = 10%)
+		}),
+		[]
+	);
+
+	// ============================================================================
+	// 1. 核心渲染逻辑 (Canvas)
+	// ============================================================================
 	const renderMinimap = React.useCallback(() => {
-		if (!editor || !canvasRef.current || !enabled) return;
+		if (!editor || !canvasRef.current || !containerRef.current || !enabled)
+			return;
 
 		const canvas = canvasRef.current;
 		const ctx = canvas.getContext("2d");
@@ -24,147 +47,220 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 		const session = editor.getSession();
 		const totalLines = session.getLength();
 
-		// 设置 canvas 尺寸
+		// 计算 Minimap 所需的真实高度
+		const requiredHeight = totalLines * config.lineHeight;
+		const parentHeight = editor.container.clientHeight;
+
+		// --- 容器高度自适应 ---
+		// 短文档：容器高度 = 代码真实高度
+		// 长文档：容器高度 = 父容器视口高度
+		const containerHeight = Math.min(requiredHeight, parentHeight);
+		containerRef.current.style.height = `${containerHeight}px`;
+
+		// --- 处理高清屏 (DPR) ---
 		const dpr = window.devicePixelRatio || 1;
-		const canvasWidth = canvas.offsetWidth * dpr;
-		const canvasHeight = canvas.offsetHeight * dpr;
+		const displayWidth = containerRef.current.clientWidth;
 
-		canvas.width = canvasWidth;
-		canvas.height = canvasHeight;
-
-		// 缩放 canvas 以适应高分辨率屏幕
-		ctx.scale(dpr, dpr);
-
-		// 获取编辑器主题颜色
-		const computedStyle = window.getComputedStyle(editor.container);
-		const backgroundColor =
-			computedStyle.backgroundColor || "rgb(255, 255, 255)";
-		const textColor = computedStyle.color || "rgb(0, 0, 0)";
-
-		// 绘制背景
-		ctx.fillStyle = backgroundColor;
-		ctx.fillRect(0, 0, canvas.offsetWidth, canvas.offsetHeight);
-
-		// 设置文字颜色（降低透明度）
-		const rgbMatch = textColor.match(/\d+/g);
-		if (rgbMatch && rgbMatch.length >= 3) {
-			ctx.fillStyle = `rgba(${rgbMatch[0]}, ${rgbMatch[1]}, ${rgbMatch[2]}, 0.4)`;
-		} else {
-			ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
+		// 只有尺寸变动时才重设 Canvas 大小 (避免闪烁)
+		if (
+			canvas.width !== displayWidth * dpr ||
+			canvas.height !== containerHeight * dpr
+		) {
+			canvas.width = displayWidth * dpr;
+			canvas.height = containerHeight * dpr;
+			ctx.scale(dpr, dpr);
 		}
 
-		const lineHeight = 2; // minimap 中每行的高度（像素）
-		const charWidth = 1.2; // minimap 中每个字符的宽度（像素）
+		ctx.clearRect(0, 0, displayWidth, containerHeight);
 
-		// 计算可见区域
-		const maxVisibleLines = Math.floor(canvas.offsetHeight / lineHeight);
-		const startLine = 0;
-		const endLine = Math.min(totalLines, maxVisibleLines);
+		// --- 计算绘制范围 ---
+		const isShortDoc = requiredHeight <= parentHeight;
+		let startRow = 0;
 
-		// 逐行渲染
-		for (let i = startLine; i < endLine; i++) {
-			const line = session.getLine(i);
-			if (!line) continue;
+		if (!isShortDoc) {
+			// 长文档：计算偏移量，使 Minimap 尽量跟随主编辑器视野
+			const firstRow = editor.getFirstVisibleRow();
+			const lastRow = editor.getLastVisibleRow();
+			const visibleRows = lastRow - firstRow;
+			const canvasCapacity = Math.floor(
+				containerHeight / config.lineHeight
+			);
 
-			const y = i * lineHeight;
-
-			// 简化渲染：只绘制非空白字符的位置
-			for (let j = 0; j < line.length; j++) {
-				const char = line[j];
-				if (char && char.trim() !== "") {
-					const x = j * charWidth;
-					ctx.fillRect(x, y, charWidth, lineHeight);
-				}
+			if (totalLines > canvasCapacity) {
+				const centerRow = firstRow + visibleRows / 2;
+				startRow = centerRow - canvasCapacity / 2;
+				// 边界限制
+				if (startRow < 0) startRow = 0;
+				if (startRow + canvasCapacity > totalLines)
+					startRow = totalLines - canvasCapacity;
 			}
 		}
-	}, [editor, enabled]);
 
-	// 更新滑块位置
+		const endLine = Math.min(
+			totalLines,
+			startRow + Math.ceil(containerHeight / config.lineHeight)
+		);
+
+		// --- 逐行绘制 ---
+		for (let i = Math.floor(startRow); i < endLine; i++) {
+			const tokens = session.getTokens(i);
+			// 如果是长文档，Y 坐标需要减去 startRow 偏移
+			const y = (i - startRow) * config.lineHeight;
+			let x = 0;
+
+			tokens.forEach((token) => {
+				const { type, value } = token;
+				let fillStyle = TOKEN_COLORS.default;
+
+				// 简单映射 Token 类型到颜色
+				if (type.includes("comment")) fillStyle = TOKEN_COLORS.comment;
+				else if (type.includes("string"))
+					fillStyle = TOKEN_COLORS.string;
+				else if (type.includes("keyword"))
+					fillStyle = TOKEN_COLORS.keyword;
+				else if (type.includes("constant"))
+					fillStyle = TOKEN_COLORS.constant;
+
+				ctx.fillStyle = fillStyle;
+
+				// 只绘制非空字符
+				if (value.trim().length > 0) {
+					ctx.fillRect(
+						x,
+						y + 0.5,
+						value.length * config.charWidth,
+						config.lineHeight - 1
+					);
+				}
+				x += value.length * config.charWidth;
+			});
+		}
+	}, [editor, enabled, config]);
+
+	// ============================================================================
+	// 2. 更新滑块位置 (Editor -> Minimap)
+	// ============================================================================
 	const updateSlider = React.useCallback(() => {
-		if (!editor || !sliderRef.current || !canvasRef.current || !enabled)
+		// 拖拽中不更新，防止抖动
+		if (isDraggingRef.current) return;
+		if (!editor || !sliderRef.current || !containerRef.current || !enabled)
 			return;
 
 		const session = editor.getSession();
-		const renderer = editor.renderer;
-		const scrollTop = session.getScrollTop();
 		const totalLines = session.getLength();
-		const lineHeight = renderer.lineHeight;
-		const editorHeight = editor.container.clientHeight;
-		const canvasHeight = canvasRef.current.offsetHeight;
+		const lineHeight = editor.renderer.lineHeight;
 
-		// 边界检查：防止除零和无效值
-		if (
-			totalLines === 0 ||
-			lineHeight === 0 ||
-			editorHeight === 0 ||
-			canvasHeight === 0
-		) {
-			sliderRef.current.style.setProperty("--minimap-slider-top", `0px`);
-			return;
+		const scrollTop = session.getScrollTop();
+		const editorHeight = editor.renderer.getContainerElement().clientHeight;
+
+		const minimapTotalHeight = totalLines * config.lineHeight;
+		const containerHeight = containerRef.current.clientHeight;
+
+		// 判断模式
+		const isShortDoc = minimapTotalHeight <= editorHeight;
+
+		if (isShortDoc) {
+			// --- 短文档模式：线性映射 ---
+			const ratio = config.lineHeight / lineHeight;
+			const sliderTop = scrollTop * ratio;
+
+			// 滑块高度按比例
+			let sliderHeight = editorHeight * ratio;
+			sliderHeight = Math.min(sliderHeight, containerHeight);
+			if (sliderHeight < 5) sliderHeight = 5; // 最小可见性
+
+			sliderRef.current.style.height = `${sliderHeight}px`;
+			sliderRef.current.style.transform = `translateY(${sliderTop}px)`;
+		} else {
+			// --- 长文档模式：滚动条映射 ---
+			// 固定滑块高度 (10% of Editor Height)
+			const fixedHeight = editorHeight * config.sliderRatio;
+			sliderRef.current.style.height = `${fixedHeight}px`;
+
+			const totalEditorHeight = totalLines * lineHeight;
+			const maxScrollTop = Math.max(0, totalEditorHeight - editorHeight);
+			const maxSliderTop = Math.max(0, containerHeight - fixedHeight);
+
+			if (maxScrollTop === 0) {
+				sliderRef.current.style.transform = `translateY(0px)`;
+				return;
+			}
+
+			const scrollRatio = scrollTop / maxScrollTop;
+			const sliderTop = scrollRatio * maxSliderTop;
+
+			sliderRef.current.style.transform = `translateY(${sliderTop}px)`;
 		}
+	}, [editor, enabled, config]);
 
-		// 计算滑块位置（固定高度）
-		const totalHeight = totalLines * lineHeight;
-		const scrollRatio = totalHeight > 0 ? scrollTop / totalHeight : 0;
-		const sliderTop = scrollRatio * canvasHeight;
-
-		// 使用 CSS 变量更新滑块位置
-		sliderRef.current.style.setProperty(
-			"--minimap-slider-top",
-			`${Math.max(0, Math.min(sliderTop, canvasHeight))}px`
-		);
-	}, [editor, enabled]);
-
-	// 处理点击事件
-	const handleCanvasClick = React.useCallback(
-		(e: React.MouseEvent<HTMLCanvasElement>) => {
-			if (!editor || !canvasRef.current) return;
-
-			const rect = canvasRef.current.getBoundingClientRect();
-			const y = e.clientY - rect.top;
-			const totalHeight = canvasRef.current.offsetHeight;
-			const session = editor.getSession();
-			const totalLines = session.getLength();
-
-			// 计算点击位置对应的行号
-			const targetLine = Math.floor((y / totalHeight) * totalLines);
-
-			// 滚动到目标行
-			editor.scrollToLine(targetLine, true, true, () => {});
-		},
-		[editor]
-	);
-
-	// 处理滑块拖动
+	// ============================================================================
+	// 3. 处理滑块拖拽 (Minimap -> Editor)
+	// ============================================================================
 	const handleSliderMouseDown = React.useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
-			if (!editor || !canvasRef.current) return;
+			if (!editor || !sliderRef.current || !containerRef.current) return;
 
 			e.preventDefault();
 			e.stopPropagation();
+
 			setIsDragging(true);
+			isDraggingRef.current = true;
 
 			const startY = e.clientY;
-			const startScrollTop = editor.getSession().getScrollTop();
+			const slider = sliderRef.current;
+			const container = containerRef.current;
+
+			// 获取初始状态
+			const rect = slider.getBoundingClientRect();
+			const containerRect = container.getBoundingClientRect();
+			const startSliderTop = rect.top - containerRect.top;
+
+			const containerHeight = container.clientHeight;
+			const sliderHeight = slider.clientHeight;
+			const maxSliderTop = Math.max(0, containerHeight - sliderHeight);
+
+			const session = editor.getSession();
+			const totalLines = session.getLength();
+			const editorHeight =
+				editor.renderer.getContainerElement().clientHeight;
+			const minimapTotalHeight = totalLines * config.lineHeight;
+			const isShortDoc = minimapTotalHeight <= editorHeight;
 
 			const handleMouseMove = (moveEvent: MouseEvent) => {
-				if (!editor || !canvasRef.current) return;
-
 				const deltaY = moveEvent.clientY - startY;
-				const totalHeight = canvasRef.current.offsetHeight;
-				const session = editor.getSession();
-				const totalLines = session.getLength();
-				const lineHeight = editor.renderer.lineHeight;
+				let newSliderTop = startSliderTop + deltaY;
 
-				// 计算滚动比例
-				const scrollRatio = deltaY / totalHeight;
-				const scrollDelta = scrollRatio * totalLines * lineHeight;
+				// 限制在容器内
+				newSliderTop = Math.max(
+					0,
+					Math.min(newSliderTop, maxSliderTop)
+				);
 
-				session.setScrollTop(startScrollTop + scrollDelta);
+				// 视觉更新
+				slider.style.transform = `translateY(${newSliderTop}px)`;
+
+				// 反向计算 ScrollTop
+				if (isShortDoc) {
+					const ratio =
+						config.lineHeight / editor.renderer.lineHeight;
+					session.setScrollTop(newSliderTop / ratio);
+				} else {
+					const totalEditorHeight =
+						session.getScreenLength() * editor.renderer.lineHeight;
+					const maxScrollTop = Math.max(
+						0,
+						totalEditorHeight - editorHeight
+					);
+					const ratio =
+						maxSliderTop > 0 ? newSliderTop / maxSliderTop : 0;
+					session.setScrollTop(ratio * maxScrollTop);
+				}
 			};
 
 			const handleMouseUp = () => {
 				setIsDragging(false);
+				isDraggingRef.current = false;
+				updateSlider(); // 最后校准一次
 				document.removeEventListener("mousemove", handleMouseMove);
 				document.removeEventListener("mouseup", handleMouseUp);
 			};
@@ -172,69 +268,107 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 			document.addEventListener("mousemove", handleMouseMove);
 			document.addEventListener("mouseup", handleMouseUp);
 		},
-		[editor]
+		[editor, updateSlider, config]
 	);
 
-	// 处理容器鼠标进入/离开
-	const handleContainerMouseEnter = React.useCallback(() => {
-		setIsHovering(true);
-	}, []);
+	// ============================================================================
+	// 4. 处理点击跳转
+	// ============================================================================
+	const handleCanvasClick = React.useCallback(
+		(e: React.MouseEvent<HTMLCanvasElement>) => {
+			if (
+				!editor ||
+				!canvasRef.current ||
+				!containerRef.current ||
+				!sliderRef.current
+			)
+				return;
 
-	const handleContainerMouseLeave = React.useCallback(() => {
-		if (!isDragging) {
-			setIsHovering(false);
-		}
-	}, [isDragging]);
+			const canvas = canvasRef.current;
+			const rect = canvas.getBoundingClientRect();
+			const clickY = e.clientY - rect.top;
 
-	// 监听编辑器事件
+			const session = editor.getSession();
+			const totalLines = session.getLength();
+			const editorHeight =
+				editor.renderer.getContainerElement().clientHeight;
+			const minimapTotalHeight = totalLines * config.lineHeight;
+			const isShortDoc = minimapTotalHeight <= editorHeight;
+
+			if (isShortDoc) {
+				// 短文档：直接跳转到对应行
+				const targetLine = Math.floor(clickY / config.lineHeight);
+				editor.scrollToLine(targetLine, true, true, () => {});
+			} else {
+				// 长文档：将滑块中心移动到点击位置
+				const containerHeight = containerRef.current.clientHeight;
+				const sliderHeight = sliderRef.current.clientHeight;
+
+				let targetSliderTop = clickY - sliderHeight / 2;
+				const maxSliderTop = Math.max(
+					0,
+					containerHeight - sliderHeight
+				);
+				targetSliderTop = Math.max(
+					0,
+					Math.min(targetSliderTop, maxSliderTop)
+				);
+
+				const totalEditorHeight =
+					totalLines * editor.renderer.lineHeight;
+				const maxScrollTop = Math.max(
+					0,
+					totalEditorHeight - editorHeight
+				);
+				const ratio =
+					maxSliderTop > 0 ? targetSliderTop / maxSliderTop : 0;
+
+				session.setScrollTop(ratio * maxScrollTop);
+			}
+		},
+		[editor, config]
+	);
+
+	// ============================================================================
+	// 5. 生命周期管理
+	// ============================================================================
 	React.useEffect(() => {
 		if (!editor || !enabled) return;
 
-		const handleChange = () => {
-			renderMinimap();
-			updateSlider();
-		};
-		const handleScroll = () => updateSlider();
-		const handleRender = () => {
-			renderMinimap();
-			updateSlider();
-		};
-		const handleResize = () => {
+		let rAF: number;
+		const tick = () => {
 			renderMinimap();
 			updateSlider();
 		};
 
-		// 绑定事件
-		editor.on("change", handleChange);
-		editor.getSession().on("changeScrollTop", handleScroll);
-		editor.renderer.on("afterRender", handleRender);
-		window.addEventListener("resize", handleResize);
+		// 绑定 Ace 事件
+		editor.on("change", tick);
+		editor.renderer.on("afterRender", tick);
+		editor.session.on("changeScrollTop", updateSlider);
+		window.addEventListener("resize", tick);
 
-		// 初始渲染 - 使用 requestAnimationFrame 确保 DOM 已经更新
-		requestAnimationFrame(() => {
-			renderMinimap();
-			updateSlider();
-		});
+		// 初始渲染
+		rAF = requestAnimationFrame(tick);
 
-		// 清理
 		return () => {
-			editor.off("change", handleChange);
-			editor.getSession().off("changeScrollTop", handleScroll);
-			editor.renderer.off("afterRender", handleRender);
-			window.removeEventListener("resize", handleResize);
+			editor.off("change", tick);
+			editor.renderer.off("afterRender", tick);
+			editor.session.off("changeScrollTop", updateSlider);
+			window.removeEventListener("resize", tick);
+			cancelAnimationFrame(rAF);
 		};
 	}, [editor, enabled, renderMinimap, updateSlider]);
 
-	if (!enabled) {
-		return null;
-	}
+	if (!enabled) return null;
 
 	return (
 		<div
 			ref={containerRef}
 			className="ace-minimap-container"
-			onMouseEnter={handleContainerMouseEnter}
-			onMouseLeave={handleContainerMouseLeave}
+			onMouseEnter={() => setIsHovering(true)}
+			onMouseLeave={() => {
+				if (!isDragging) setIsHovering(false);
+			}}
 		>
 			<canvas
 				ref={canvasRef}

--- a/styles/Minimap.css
+++ b/styles/Minimap.css
@@ -1,79 +1,44 @@
-/* Minimap 容器 */
 .ace-minimap-container {
 	position: absolute;
 	right: 0;
 	top: 0;
-	bottom: 0;
-	width: 10dvw; /* 默认宽度为视口宽度的 10% */
-	background-color: var(--background-primary);
-	border-left: 1px solid var(--background-modifier-border);
+	max-height: 100%;
+	width: 10dvw;
+	background-color: var(--background-primary, #1e1e1e);
+	border-left: 1px solid var(--background-modifier-border, #333);
+	z-index: 100;
 	overflow: hidden;
-	z-index: 10;
+	transition: height 0.1s ease-out;
 	box-sizing: border-box;
 }
 
-/* Minimap Canvas */
 .ace-minimap-canvas {
 	display: block;
 	width: 100%;
 	height: 100%;
-	cursor: pointer;
-	user-select: none;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
+	cursor: text;
+	pointer-events: auto;
 }
 
-/* 视口滑块 */
 .ace-minimap-slider {
 	position: absolute;
-	right: 0;
 	left: 0;
-	top: var(--minimap-slider-top, 0);
-	height: 10dvh; /* 固定高度 */
-	background-color: var(--interactive-accent);
+	right: 0;
+	top: 0;
+	background-color: rgba(120, 120, 120, 0.2);
+	box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1) inset;
+	cursor: grab;
+	pointer-events: auto;
+	transition: opacity 0.2s;
 	opacity: 0;
-	border: 1px solid var(--interactive-accent);
-	cursor: pointer;
-	pointer-events: all;
-	transition: opacity 0.2s ease-in-out;
-	box-sizing: border-box;
-	border-radius: 3px;
 }
 
-/* 鼠标悬停在容器上时显示 slider */
 .ace-minimap-slider.visible {
-	opacity: 0.15;
+	opacity: 1;
 }
 
-/* 鼠标悬停在 slider 上时加深 */
-.ace-minimap-slider.visible:hover {
-	opacity: 0.3;
-}
-
-/* 拖动时再次加深 */
 .ace-minimap-slider.dragging {
-	opacity: 0.4 !important;
-}
-
-/* 暗色主题调整 */
-.theme-dark .ace-minimap-container {
-	background-color: var(--background-primary-alt);
-	border-left-color: var(--background-modifier-border);
-}
-
-.theme-dark .ace-minimap-slider {
-	background-color: var(--interactive-accent);
-	border-color: var(--interactive-accent);
-}
-
-/* 亮色主题调整 */
-.theme-light .ace-minimap-container {
-	background-color: var(--background-secondary);
-	border-left-color: var(--background-modifier-border);
-}
-
-.theme-light .ace-minimap-slider {
-	background-color: var(--interactive-accent);
-	border-color: var(--interactive-accent);
+	cursor: grabbing;
+	background-color: rgba(120, 120, 120, 0.4);
+	box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2) inset;
 }


### PR DESCRIPTION
新增并重构 Minimap 渲染逻辑以提升视觉一致性和性能。
主要改动包括：
- 增加语法高亮颜色映射，基于 token 类型用不同颜色绘制代码
  语法，提升小地图的可读性。
- 引入 containerRef 并根据文档长度自适应容器高度：
  短文档使用代码真实高度，长文档限制为编辑器视口高度，
  避免小地图过长或过短导致的显示问题。
- 支持设备像素比 (DPR) 的正确处理，只有在 Canvas 尺寸变更时
  才重设画布并缩放，减少重绘闪烁并提升高清屏显示清晰度。
- 按行计算绘制范围：对长文档根据主编辑器可见行范围居中
  渲染小地图内容，保持小地图与编辑器视图的关联性。
- 增加拖拽相关的状态引用和配置项（行高、字符宽、滑块比）
  为后续交互与性能调优预留接口。

为什么要做这些改动：
- 提升小地图在不同主题和高分屏下的视觉一致性和清晰度。
- 减少不必要的重绘，提高性能并避免闪烁。
- 使小地图在短/长文档场景下均能合理展示并与编辑器视图对齐。