### PR TITLE
feat(modal): 点击遮罩关闭并添加容器类

### DIFF
--- a/src/component/modal/BaseModal.tsx
+++ b/src/component/modal/BaseModal.tsx
@@ -37,6 +37,14 @@ export class BaseModal<T extends { onClose: () => void }> extends Modal {
 
 	async onOpen(): Promise<void> {
 		const el = this.containerEl;
+		el.classList.add("ace-modal-container");
+
+		el.addEventListener("click", (e) => {
+			if (e.target === el) {
+				this.close();
+			}
+		});
+
 		this.root = createRoot(el);
 		this.root.render(
 			<React.StrictMode>


### PR DESCRIPTION
在 BaseModal 中对弹窗容器元素做两项关键改动：
- 为容器添加了 ace-modal-container 类，方便样式和选择器统一管理。
- 在容器上绑定点击事件，若点击目标正是容器（即点击遮罩区域）则调用 close()，
  实现点击遮罩关闭弹窗的交互。

这样做的原因是提升用户体验与样式可控性：
- 遮罩点击关闭是常见习惯，能让用户更方便地关闭模态框；
- 明确的容器类便于后续样式定制或选择器定位，减少对内部结构的耦合。