### PR TITLE
refactor: React hooks 简化组件和钩子导入

### DIFF
--- a/src/component/confirm-dialog/ConfirmDialog.tsx
+++ b/src/component/confirm-dialog/ConfirmDialog.tsx
@@ -1,7 +1,7 @@
 import { t } from "@src/i18n/i18n";
 import AceCodeEditorPlugin from "@src/main";
 import { Modal } from "obsidian";
-import * as React from "react";
+import { StrictMode } from "react";
 import { createRoot, Root } from "react-dom/client";
 import "./ConfirmDialog.css";
 
@@ -61,14 +61,14 @@ export class ConfirmDialog extends Modal {
 		this.root = createRoot(contentEl);
 
 		this.root.render(
-			<React.StrictMode>
+			<StrictMode>
 				<ConfirmDialogView
 					title={this.props.title}
 					message={this.props.message}
 					onConfirm={this.props.onConfirm}
 					onClose={() => this.close()}
 				/>
-			</React.StrictMode>
+			</StrictMode>
 		);
 	}
 

--- a/src/component/icon-picker/IconPicker.tsx
+++ b/src/component/icon-picker/IconPicker.tsx
@@ -6,7 +6,7 @@ import {
 	IconName,
 	setIcon,
 } from "obsidian";
-import * as React from "react";
+import { useEffect, useRef, useState } from "react";
 import "./IconPicker.css";
 
 interface IconPickerProps {
@@ -20,8 +20,8 @@ export const IconPicker: React.FC<IconPickerProps> = ({
 	value,
 	onChange,
 }) => {
-	const [selectedIcon, setSelectedIcon] = React.useState<string>(value);
-	const buttonRef = React.useRef<HTMLDivElement>(null);
+	const [selectedIcon, setSelectedIcon] = useState<string>(value);
+	const buttonRef = useRef<HTMLDivElement>(null);
 
 	const handleClick = () => {
 		const modal = new IconSelector(app, (icon) => {
@@ -31,7 +31,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
 		modal.open();
 	};
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (buttonRef.current) {
 			setIcon(buttonRef.current, selectedIcon);
 		}

--- a/src/component/input/Input.tsx
+++ b/src/component/input/Input.tsx
@@ -1,4 +1,10 @@
-import * as React from "react";
+import {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useRef,
+} from "react";
 import "./Input.css";
 
 interface InputProps
@@ -12,7 +18,7 @@ interface InputProps
 	onChange: (value: string) => void;
 }
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+export const Input = forwardRef<HTMLInputElement, InputProps>(
 	(
 		{
 			className = "",
@@ -25,14 +31,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 		},
 		ref
 	) => {
-		const inputRef = React.useRef<HTMLInputElement>(null);
-		const isComposingRef = React.useRef(false);
+		const inputRef = useRef<HTMLInputElement>(null);
+		const isComposingRef = useRef(false);
 
 		// 合并外部ref和内部ref
-		React.useImperativeHandle(ref, () => inputRef.current!);
+		useImperativeHandle(ref, () => inputRef.current!);
 
 		// 强制设置value的函数
-		const forceSetValue = React.useCallback(() => {
+		const forceSetValue = useCallback(() => {
 			if (inputRef.current && value !== undefined) {
 				const stringValue = String(value);
 				if (inputRef.current.value !== stringValue) {
@@ -43,7 +49,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 		}, [value]);
 
 		// 在value变化时强制更新DOM
-		React.useEffect(() => {
+		useEffect(() => {
 			if (!isComposingRef.current) {
 				forceSetValue();
 			}

--- a/src/component/modal/BaseModal.tsx
+++ b/src/component/modal/BaseModal.tsx
@@ -1,7 +1,7 @@
 import AceCodeEditorPlugin from "@src/main";
 import { X } from "lucide-react";
 import { App, Modal } from "obsidian";
-import * as React from "react";
+import { lazy, StrictMode, Suspense } from "react";
 import { createRoot, Root } from "react-dom/client";
 
 const ModalLoading: React.FC = () => (
@@ -24,7 +24,7 @@ export class BaseModal<T extends { onClose: () => void }> extends Modal {
 		sizeClass = "modal-size-large"
 	) {
 		super(app);
-		this.LazyComponent = React.lazy(componentImport);
+		this.LazyComponent = lazy(componentImport);
 		this.componentProps = {
 			...props,
 			onClose: () => {
@@ -47,11 +47,11 @@ export class BaseModal<T extends { onClose: () => void }> extends Modal {
 
 		this.root = createRoot(el);
 		this.root.render(
-			<React.StrictMode>
+			<StrictMode>
 				<div className={`ace-modal ${this.sizeClass}`}>
-					<React.Suspense fallback={<ModalLoading />}>
+					<Suspense fallback={<ModalLoading />}>
 						<this.LazyComponent {...this.componentProps} />
-					</React.Suspense>
+					</Suspense>
 					<div
 						className="ace-modal-close"
 						onClick={() => this.close()}
@@ -59,7 +59,7 @@ export class BaseModal<T extends { onClose: () => void }> extends Modal {
 						<X size={18} />
 					</div>
 				</div>
-			</React.StrictMode>
+			</StrictMode>
 		);
 	}
 

--- a/src/component/modal/CreateCodeFileModal.tsx
+++ b/src/component/modal/CreateCodeFileModal.tsx
@@ -2,7 +2,7 @@ import { Input } from "@src/component/input/Input";
 import { Select } from "@src/component/select/Select";
 import { t } from "@src/i18n/i18n";
 import { App, normalizePath, Notice } from "obsidian";
-import * as React from "react";
+import { useState } from "react";
 
 interface CreateCodeFileModalProps {
 	onClose: () => void;
@@ -34,10 +34,10 @@ const CreateCodeFileModal: React.FC<CreateCodeFileModalProps> = ({
 	folderPath,
 	openInCodeEditor,
 }) => {
-	const [fileName, setFileName] = React.useState("");
-	const [fileExtension, setFileExtension] = React.useState("custom");
-	const [openAfterCreate, setOpenAfterCreate] = React.useState(true);
-	const [isCustomFilename, setIsCustomFilename] = React.useState(true);
+	const [fileName, setFileName] = useState("");
+	const [fileExtension, setFileExtension] = useState("custom");
+	const [openAfterCreate, setOpenAfterCreate] = useState(true);
+	const [isCustomFilename, setIsCustomFilename] = useState(true);
 
 	const handleFileExtensionChange = (value: string) => {
 		setFileExtension(value);

--- a/src/component/modal/EditCodeBlockModal.tsx
+++ b/src/component/modal/EditCodeBlockModal.tsx
@@ -2,7 +2,7 @@ import { t } from "@src/i18n/i18n";
 import { AceService } from "@src/service/AceService";
 import { ICodeBlock, ICodeEditorConfig } from "@src/type/types";
 import { Ace } from "ace-builds";
-import * as React from "react";
+import { useEffect, useRef } from "react";
 
 interface EditCodeBlockModalProps {
 	onClose: () => void;
@@ -17,11 +17,11 @@ const EditCodeBlockModal: React.FC<EditCodeBlockModalProps> = ({
 	onSave,
 	config,
 }) => {
-	const editorRef = React.useRef<HTMLDivElement>(null);
-	const aceEditorRef = React.useRef<Ace.Editor | null>(null);
-	const aceServiceRef = React.useRef<AceService | null>(null);
+	const editorRef = useRef<HTMLDivElement>(null);
+	const aceEditorRef = useRef<Ace.Editor | null>(null);
+	const aceServiceRef = useRef<AceService | null>(null);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (editorRef.current && !aceEditorRef.current) {
 			aceServiceRef.current = new AceService();
 			aceEditorRef.current = aceServiceRef.current.createEditor(

--- a/src/component/modal/SnippetsFileModal.tsx
+++ b/src/component/modal/SnippetsFileModal.tsx
@@ -2,6 +2,7 @@ import { ConfirmDialog } from "@src/component/confirm-dialog/ConfirmDialog";
 import { Input } from "@src/component/input/Input";
 import { Toggle } from "@src/component/toggle/Toggle";
 import { t } from "@src/i18n/i18n";
+import AceCodeEditorPlugin from "@src/main";
 import {
 	Code2,
 	FilePlus2,
@@ -13,9 +14,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { App, Notice } from "obsidian";
-import * as React from "react";
-
-import AceCodeEditorPlugin from "@src/main";
+import { useEffect, useRef, useState } from "react";
 
 interface SnippetsFileModalProps {
 	onClose: () => void;
@@ -38,17 +37,17 @@ const SnippetsFileModal: React.FC<SnippetsFileModalProps> = ({
 	snippetsFolder,
 	openExternalFile,
 }) => {
-	const [files, setFiles] = React.useState<SnippetFile[]>([]);
-	const [isCreatingNew, setIsCreatingNew] = React.useState(false);
-	const [newFileName, setNewFileName] = React.useState("");
-	const [searchQuery, setSearchQuery] = React.useState("");
-	const newFileInputRef = React.useRef<HTMLInputElement>(null);
+	const [files, setFiles] = useState<SnippetFile[]>([]);
+	const [isCreatingNew, setIsCreatingNew] = useState(false);
+	const [newFileName, setNewFileName] = useState("");
+	const [searchQuery, setSearchQuery] = useState("");
+	const newFileInputRef = useRef<HTMLInputElement>(null);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		loadSnippetsFiles();
 	}, []);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (isCreatingNew && newFileInputRef.current) {
 			newFileInputRef.current.focus();
 		}

--- a/src/component/select/Select.tsx
+++ b/src/component/select/Select.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
-import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import "./Select.css";
 
 export interface SelectOption {
@@ -22,16 +22,16 @@ export const Select: React.FC<SelectProps> = ({
 	placeholder = "Select an option",
 	className = "",
 }) => {
-	const [isOpen, setIsOpen] = React.useState(false);
-	const selectRef = React.useRef<HTMLDivElement>(null);
-	const dropdownRef = React.useRef<HTMLDivElement>(null);
-	const selectedOptionRef = React.useRef<HTMLDivElement>(null);
+	const [isOpen, setIsOpen] = useState(false);
+	const selectRef = useRef<HTMLDivElement>(null);
+	const dropdownRef = useRef<HTMLDivElement>(null);
+	const selectedOptionRef = useRef<HTMLDivElement>(null);
 
 	const selectedOption = options.find((opt) => opt.value === value);
 	const selectedIndex = options.findIndex((opt) => opt.value === value);
 
 	// 虚拟滚动相关状态
-	const [visibleStartIndex, setVisibleStartIndex] = React.useState(0);
+	const [visibleStartIndex, setVisibleStartIndex] = useState(0);
 	const itemHeight = 36; // 选项高度，需根据实际CSS调整
 	const visibleItems = 10; // 一次渲染的可见项数量
 	const bufferItems = 5; // 缓冲项数量，提高滚动体验
@@ -48,7 +48,7 @@ export const Select: React.FC<SelectProps> = ({
 	);
 
 	// 处理滚动事件
-	const handleScroll = React.useCallback(
+	const handleScroll = useCallback(
 		(e: React.UIEvent<HTMLDivElement>) => {
 			const scrollTop = e.currentTarget.scrollTop;
 			const newStartIndex = Math.floor(scrollTop / itemHeight);
@@ -58,7 +58,7 @@ export const Select: React.FC<SelectProps> = ({
 	);
 
 	// 打开下拉框时滚动到选中项
-	React.useEffect(() => {
+	useEffect(() => {
 		if (isOpen && dropdownRef.current && selectedIndex >= 0) {
 			const scrollPosition = selectedIndex * itemHeight;
 			dropdownRef.current.scrollTop = scrollPosition;
@@ -68,7 +68,7 @@ export const Select: React.FC<SelectProps> = ({
 		}
 	}, [isOpen, selectedIndex, itemHeight, visibleItems]);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
 			if (
 				selectRef.current &&

--- a/src/component/tab-nav/TabNav.tsx
+++ b/src/component/tab-nav/TabNav.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from "radix-ui";
-import * as React from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import "./TabNav.css";
 
 export interface TabNavItem {
@@ -26,12 +26,12 @@ export const TabNav: React.FC<TabNavProps> = ({
 }) => {
 	const enabledTabs = tabs.filter((tab) => !tab.disabled);
 	const defaultTab = defaultValue || enabledTabs[0]?.id;
-	const scrollContainerRef = React.useRef<HTMLDivElement>(null);
-	const scrollPositionRef = React.useRef<{ [key: string]: number }>({});
-	const [currentTab, setCurrentTab] = React.useState(defaultTab);
+	const scrollContainerRef = useRef<HTMLDivElement>(null);
+	const scrollPositionRef = useRef<{ [key: string]: number }>({});
+	const [currentTab, setCurrentTab] = useState(defaultTab);
 
 	// 监听标签切换，保存当前滚动位置
-	const handleTabChange = React.useCallback(
+	const handleTabChange = useCallback(
 		(value: string) => {
 			// 保存当前标签的滚动位置
 			if (scrollContainerRef.current && currentTab) {
@@ -57,7 +57,7 @@ export const TabNav: React.FC<TabNavProps> = ({
 	);
 
 	// 在组件更新后保持滚动位置
-	React.useLayoutEffect(() => {
+	useLayoutEffect(() => {
 		if (
 			scrollContainerRef.current &&
 			currentTab &&
@@ -69,7 +69,7 @@ export const TabNav: React.FC<TabNavProps> = ({
 	});
 
 	// 监听滚动事件，实时保存滚动位置
-	const handleScroll = React.useCallback(() => {
+	const handleScroll = useCallback(() => {
 		if (scrollContainerRef.current && currentTab) {
 			scrollPositionRef.current[currentTab] =
 				scrollContainerRef.current.scrollTop;

--- a/src/component/tag-input/TagInput.tsx
+++ b/src/component/tag-input/TagInput.tsx
@@ -1,5 +1,5 @@
 import { X } from "lucide-react";
-import * as React from "react";
+import { useRef, useState } from "react";
 import "./TagInput.css";
 
 interface TagInputProps {
@@ -17,14 +17,14 @@ export const TagInput: React.FC<TagInputProps> = ({
 	placeholder,
 	renderCustomSuggestion,
 }) => {
-	const [inputValue, setInputValue] = React.useState("");
-	const [showSuggestions, setShowSuggestions] = React.useState(false);
-	const [selectedIndex, setSelectedIndex] = React.useState(-1);
-	const containerRef = React.useRef<HTMLDivElement>(null);
-	const [draggedTag, setDraggedTag] = React.useState<number | null>(null);
-	const [dragOverTag, setDragOverTag] = React.useState<number | null>(null);
+	const [inputValue, setInputValue] = useState("");
+	const [showSuggestions, setShowSuggestions] = useState(false);
+	const [selectedIndex, setSelectedIndex] = useState(-1);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [draggedTag, setDraggedTag] = useState<number | null>(null);
+	const [dragOverTag, setDragOverTag] = useState<number | null>(null);
 
-	const filteredSuggestions = React.useMemo(() => {
+	const filteredSuggestions = useMemo(() => {
 		return suggestions.filter(
 			(suggestion) =>
 				suggestion.toLowerCase().includes(inputValue.toLowerCase()) &&

--- a/src/component/toggle/Toggle.tsx
+++ b/src/component/toggle/Toggle.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useCallback } from "react";
 import "./Toggle.css";
 
 interface ToggleProps {
@@ -14,11 +14,11 @@ export const Toggle: React.FC<ToggleProps> = ({
 	className = "",
 	"aria-label": ariaLabel,
 }) => {
-	const handleChange = React.useCallback(() => {
+	const handleChange = useCallback(() => {
 		onChange(!checked);
 	}, [checked, onChange]);
 
-	const handleKeyDown = React.useCallback(
+	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
 			if (e.key === "Enter" || e.key === " ") {
 				e.preventDefault();

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,6 +1,6 @@
 import AceCodeEditorPlugin from "@src/main";
 import { ICodeEditorConfig } from "@src/type/types";
-import * as React from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export const SettingsBus = {
 	listeners: new Set<() => void>(),
@@ -20,11 +20,11 @@ export const SettingsBus = {
 };
 
 export function useSettings(plugin: AceCodeEditorPlugin) {
-	const [settings, setSettings] = React.useState<ICodeEditorConfig>(
+	const [settings, setSettings] = useState<ICodeEditorConfig>(
 		plugin.getSettings()
 	);
 
-	const updateSettings = React.useCallback(
+	const updateSettings = useCallback(
 		async (newSettings: ICodeEditorConfig) => {
 			await plugin.updateSettings(newSettings);
 			setSettings(newSettings);
@@ -33,7 +33,7 @@ export function useSettings(plugin: AceCodeEditorPlugin) {
 		[plugin]
 	);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		setSettings(plugin.settings);
 
 		const unsubscribe = SettingsBus.subscribe(() => {

--- a/src/settings/AceSettings.tsx
+++ b/src/settings/AceSettings.tsx
@@ -15,7 +15,7 @@ import {
 } from "@src/service/AceThemes";
 import parse from "html-react-parser";
 import { Notice, Platform } from "obsidian";
-import * as React from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SettingsItem } from "./item/SettingItem";
 
 interface FontData {
@@ -39,10 +39,10 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 	const settings = usePluginSettings(settingsStore);
 	const app = settingsStore.app;
 
-	const [systemFonts, setSystemFonts] = React.useState<string[]>([]);
+	const [systemFonts, setSystemFonts] = useState<string[]>([]);
 
 	// 加载系统字体
-	React.useEffect(() => {
+	useEffect(() => {
 		async function loadSystemFonts() {
 			try {
 				let fonts: string[] = [];
@@ -226,7 +226,7 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		});
 	}
 
-	const lightThemeOptions = React.useMemo(
+	const lightThemeOptions = useMemo(
 		() =>
 			AceLightThemesList.map((theme) => ({
 				value: theme,
@@ -235,7 +235,7 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		[]
 	);
 
-	const darkThemeOptions = React.useMemo(
+	const darkThemeOptions = useMemo(
 		() =>
 			AceDarkThemesList.map((theme) => ({
 				value: theme,
@@ -244,7 +244,7 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		[]
 	);
 
-	const keyboardOptions = React.useMemo(
+	const keyboardOptions = useMemo(
 		() =>
 			AceKeyboardList.map((keyboard) => ({
 				value: keyboard,
@@ -253,11 +253,11 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		[]
 	);
 
-	const EditorSettings = React.useMemo(() => {
+	const EditorSettings = useMemo(() => {
 		return <></>;
 	}, []);
 
-	const RendererSettings = React.useMemo(() => {
+	const RendererSettings = useMemo(() => {
 		return (
 			<>
 				<SettingsItem
@@ -429,7 +429,7 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		);
 	}, [settings, systemFonts]);
 
-	const SessionSettings = React.useMemo(() => {
+	const SessionSettings = useMemo(() => {
 		return (
 			<>
 				<SettingsItem
@@ -498,7 +498,7 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		);
 	}, [settings]);
 
-	const ExtendSettings = React.useMemo(() => {
+	const ExtendSettings = useMemo(() => {
 		return (
 			<>
 				<SettingsItem
@@ -551,7 +551,7 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		);
 	}, [settings, app]);
 
-	const AboutSettings = React.useMemo(() => {
+	const AboutSettings = useMemo(() => {
 		return (
 			<>
 				<SettingsItem
@@ -562,7 +562,7 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 		);
 	}, []);
 
-	const settingsTabNavItems: TabNavItem[] = React.useMemo(
+	const settingsTabNavItems: TabNavItem[] = useMemo(
 		() => [
 			{
 				id: "renderer",

--- a/src/settings/SettingsTab.tsx
+++ b/src/settings/SettingsTab.tsx
@@ -1,7 +1,7 @@
 import { SettingsStoreContext } from "@src/context/SettingsStoreContext";
 import AceCodeEditorPlugin from "@src/main";
 import { App, PluginSettingTab } from "obsidian";
-import * as React from "react";
+import { StrictMode } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { AceSettings } from "./AceSettings";
 
@@ -36,13 +36,13 @@ export default class AceCodeEditorSettingTab extends PluginSettingTab {
 
 	private renderContent() {
 		this.root?.render(
-			<React.StrictMode>
+			<StrictMode>
 				<SettingsStoreContext.Provider
 					value={this.plugin.settingsStore}
 				>
 					<AceSettings />
 				</SettingsStoreContext.Provider>
-			</React.StrictMode>
+			</StrictMode>
 		);
 	}
 }

--- a/src/settings/item/SettingItem.tsx
+++ b/src/settings/item/SettingItem.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
-import * as React from "react";
+import { useState } from "react";
 import "./SettingItem.css";
 
 interface SettingsItemProps {
@@ -19,7 +19,7 @@ export const SettingsItem: React.FC<SettingsItemProps> = ({
 	collapsible,
 	defaultCollapsed,
 }) => {
-	const [isCollapsed, setIsCollapsed] = React.useState(defaultCollapsed);
+	const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
 
 	return (
 		<div

--- a/src/view/CodeEmbedView.tsx
+++ b/src/view/CodeEmbedView.tsx
@@ -9,7 +9,14 @@ import { parseLinkWithRange } from "@src/utils/LineRange";
 import { Ace } from "ace-builds";
 import { Maximize2 } from "lucide-react";
 import { TFile } from "obsidian";
-import * as React from "react";
+import {
+	createElement,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { createRoot, Root } from "react-dom/client";
 
 interface CodeEmbedContainerProps {
@@ -23,14 +30,14 @@ const CodeEmbedContainer: React.FC<CodeEmbedContainerProps> = ({
 	file,
 	range,
 }) => {
-	const editorRef = React.useRef<HTMLDivElement>(null);
-	const aceEditorRef = React.useRef<Ace.Editor | null>(null);
-	const aceServiceRef = React.useRef<AceService | null>(null);
-	const [lang, setLang] = React.useState<string>();
+	const editorRef = useRef<HTMLDivElement>(null);
+	const aceEditorRef = useRef<Ace.Editor | null>(null);
+	const aceServiceRef = useRef<AceService | null>(null);
+	const [lang, setLang] = useState<string>();
 
 	const { settings } = useSettings(plugin);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		const initializeEditor = async () => {
 			if (editorRef.current) {
 				const data = await plugin.app.vault.read(file);
@@ -74,7 +81,7 @@ const CodeEmbedContainer: React.FC<CodeEmbedContainerProps> = ({
 		};
 	}, []);
 
-	const displayLabel = React.useMemo(() => {
+	const displayLabel = useMemo(() => {
 		if (range) {
 			if (range.startLine === range.endLine) {
 				return `${lang} (Line ${range.startLine})`;
@@ -85,7 +92,7 @@ const CodeEmbedContainer: React.FC<CodeEmbedContainerProps> = ({
 		return lang;
 	}, [lang, range]);
 
-	const handleOpenInNewTab = React.useCallback(async () => {
+	const handleOpenInNewTab = useCallback(async () => {
 		// 使用 Obsidian API 在新标签页打开文件
 		const leaf = plugin.app.workspace.getLeaf("tab");
 		await leaf.openFile(file);
@@ -172,7 +179,7 @@ export class CodeEmbedView extends AcePluginComponent implements Embed {
 	async loadFile(): Promise<void> {
 		if (this.root) {
 			this.root.render(
-				React.createElement(CodeEmbedContainer, {
+				createElement(CodeEmbedContainer, {
 					plugin: this.plugin,
 					file: this.file,
 					range: this.range || undefined,

--- a/src/view/Minimap.tsx
+++ b/src/view/Minimap.tsx
@@ -1,5 +1,5 @@
 import * as ace from "ace-builds";
-import * as React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface MinimapProps {
 	editor: ace.Ace.Editor | null;
@@ -16,15 +16,15 @@ const TOKEN_COLORS: Record<string, string> = {
 };
 
 export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
-	const canvasRef = React.useRef<HTMLCanvasElement>(null);
-	const sliderRef = React.useRef<HTMLDivElement>(null);
-	const containerRef = React.useRef<HTMLDivElement>(null);
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const sliderRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
 
-	const [isHovering, setIsHovering] = React.useState(false);
-	const [isDragging, setIsDragging] = React.useState(false);
-	const isDraggingRef = React.useRef(false);
+	const [isHovering, setIsHovering] = useState(false);
+	const [isDragging, setIsDragging] = useState(false);
+	const isDraggingRef = useRef(false);
 
-	const config = React.useMemo(
+	const config = useMemo(
 		() => ({
 			lineHeight: 3, // Minimap 行高 (px)
 			charWidth: 2, // Minimap 字符宽 (px)
@@ -36,7 +36,7 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 	// ============================================================================
 	// 1. 核心渲染逻辑 (Canvas)
 	// ============================================================================
-	const renderMinimap = React.useCallback(() => {
+	const renderMinimap = useCallback(() => {
 		if (!editor || !canvasRef.current || !containerRef.current || !enabled)
 			return;
 
@@ -140,7 +140,7 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 	// ============================================================================
 	// 2. 更新滑块位置 (Editor -> Minimap)
 	// ============================================================================
-	const updateSlider = React.useCallback(() => {
+	const updateSlider = useCallback(() => {
 		// 拖拽中不更新，防止抖动
 		if (isDraggingRef.current) return;
 		if (!editor || !sliderRef.current || !containerRef.current || !enabled)
@@ -196,7 +196,7 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 	// ============================================================================
 	// 3. 处理滑块拖拽 (Minimap -> Editor)
 	// ============================================================================
-	const handleSliderMouseDown = React.useCallback(
+	const handleSliderMouseDown = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			if (!editor || !sliderRef.current || !containerRef.current) return;
 
@@ -274,7 +274,7 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 	// ============================================================================
 	// 4. 处理点击跳转
 	// ============================================================================
-	const handleCanvasClick = React.useCallback(
+	const handleCanvasClick = useCallback(
 		(e: React.MouseEvent<HTMLCanvasElement>) => {
 			if (
 				!editor ||
@@ -332,7 +332,7 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 	// ============================================================================
 	// 5. 生命周期管理
 	// ============================================================================
-	React.useEffect(() => {
+	useEffect(() => {
 		if (!editor || !enabled) return;
 
 		let rAF: number;

--- a/src/view/SettingsView.tsx
+++ b/src/view/SettingsView.tsx
@@ -1,7 +1,8 @@
 import AceCodeEditorPlugin from "@src/main";
 import { AceSettings } from "@src/settings/AceSettings";
 import { IconName, ItemView, WorkspaceLeaf } from "obsidian";
-import * as React from "react";
+import { StrictMode } from "react";
+
 import { createRoot, Root } from "react-dom/client";
 
 export const SETTINGS_VIEW_TYPE = "ace-code-editor-settings";
@@ -39,9 +40,9 @@ export class SettingsView extends ItemView {
 		}
 
 		this.root.render(
-			<React.StrictMode>
+			<StrictMode>
 				<AceSettings />
-			</React.StrictMode>
+			</StrictMode>
 		);
 	}
 


### PR DESCRIPTION
优化组件和自定义钩子中对 React API 的使用，统一从
react 直接按需导入 Hook 和 API，替换之前的整
体导入形式（import * as React from "react"）。主要改动：
- 在 SettingsView 中用 StrictMode 替换 React.StrictMode，避免
  整体命名空间导入。
- 在多个组件（AceSettings、CodeEmbedView 等）中把
  React.useState/useEffect/useMemo/useRef/useCallback 等替换成
 按需导入的 useState/useEffect/useMemo/useRef/useCallback，以减
  少包体并提升可读性。
- 在 useSettings 钩子中同样改用 useState/useEffect/useCallback。
- 其它细节：调整导入排序和局部变量声明一致性。

为什么要这样做：
- 减少默认/整体验证命名空间导入带来的体积与模糊性；
- 按需导入有助于编译器做更好优化并提升代码可读性；
- 统一编码风格，便于后续维护和审查。