### PR TITLE
feat(minimap): 增加缩略图显示模式并改进设置交互

### DIFF
--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -152,6 +152,11 @@ const en = {
 				name: "Enable minimap",
 				desc: "Show minimap on the right side of the editor for quick navigation",
 			},
+			mode: {
+				always: "Always show",
+				on_hover: "Show on hover",
+				hidden: "Hidden",
+			},
 		},
 	},
 } satisfies BaseTranslation;

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -457,6 +457,20 @@ type RootTranslation = {
 				 */
 				desc: string
 			}
+			mode: {
+				/**
+				 * 始​终​显​示
+				 */
+				always: string
+				/**
+				 * 悬​停​时​显​示
+				 */
+				on_hover: string
+				/**
+				 * 隐​藏
+				 */
+				hidden: string
+			}
 		}
 	}
 }
@@ -897,6 +911,20 @@ export type TranslationFunctions = {
 				 * 在编辑器右侧显示缩略图，方便快速导航代码
 				 */
 				desc: () => LocalizedString
+			}
+			mode: {
+				/**
+				 * 始终显示
+				 */
+				always: () => LocalizedString
+				/**
+				 * 悬停时显示
+				 */
+				on_hover: () => LocalizedString
+				/**
+				 * 隐藏
+				 */
+				hidden: () => LocalizedString
 			}
 		}
 	}

--- a/src/i18n/zh-TW/index.ts
+++ b/src/i18n/zh-TW/index.ts
@@ -150,6 +150,11 @@ const zh_TW = {
 				name: "啟用縮略圖",
 				desc: "在編輯器右側顯示縮略圖，方便快速導航程式碼",
 			},
+			mode: {
+				always: "始終顯示",
+				on_hover: "懸停時顯示",
+				hidden: "隱藏",
+			},
 		},
 	},
 } satisfies BaseTranslation;

--- a/src/i18n/zh/index.ts
+++ b/src/i18n/zh/index.ts
@@ -149,6 +149,11 @@ const zh = {
 				name: "启用缩略图",
 				desc: "在编辑器右侧显示缩略图，方便快速导航代码",
 			},
+			mode: {
+				always: "始终显示",
+				on_hover: "悬停时显示",
+				hidden: "隐藏",
+			},
 		},
 	},
 } satisfies BaseTranslation;

--- a/src/settings/AceSettings.tsx
+++ b/src/settings/AceSettings.tsx
@@ -416,13 +416,39 @@ export const AceSettings: React.FC<AceSettingsProps> = ({}) => {
 					name={LL.setting.minimap.enabled.name()}
 					desc={LL.setting.minimap.enabled.desc()}
 				>
-					<Toggle
-						checked={settings.minimap.enabled}
-						onChange={(value) =>
-							settingsStore.updateSettingByPath("minimap", {
-								enabled: value,
-							})
+					<Select
+						options={[
+							{
+								label: LL.setting.minimap.mode.always(),
+								value: "always",
+							},
+							{
+								label: LL.setting.minimap.mode.on_hover(),
+								value: "hover",
+							},
+							{
+								label: LL.setting.minimap.mode.hidden(),
+								value: "hidden",
+							},
+						]}
+						value={
+							!settings.minimap.enabled
+								? "hidden"
+								: settings.minimap.mode || "always"
 						}
+						onChange={(value) => {
+							if (value === "hidden") {
+								settingsStore.updateSettingByPath("minimap", {
+									enabled: false,
+									mode: "always",
+								});
+							} else {
+								settingsStore.updateSettingByPath("minimap", {
+									enabled: true,
+									mode: value as "always" | "hover",
+								});
+							}
+						}}
 					/>
 				</SettingsItem>
 			</>

--- a/src/type/types.ts
+++ b/src/type/types.ts
@@ -29,6 +29,7 @@ export interface ICodeEditorConfig {
 	wrap: boolean;
 	minimap: {
 		enabled: boolean;
+		mode: "always" | "hover";
 	};
 }
 
@@ -53,6 +54,7 @@ export const DEFAULT_CONFIG: ICodeEditorConfig = {
 	wrap: true,
 	minimap: {
 		enabled: true,
+		mode: "always",
 	},
 };
 

--- a/src/view/AceEditorView.tsx
+++ b/src/view/AceEditorView.tsx
@@ -132,6 +132,7 @@ export abstract class AceEditorView extends TextFileView {
 				<Minimap
 					editor={editor}
 					enabled={this.config.minimap.enabled}
+					mode={this.config.minimap.mode}
 				/>
 			</StrictMode>
 		);

--- a/src/view/Minimap.tsx
+++ b/src/view/Minimap.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 export interface MinimapProps {
 	editor: ace.Ace.Editor | null;
 	enabled: boolean;
+	mode?: "always" | "hover";
 }
 
 // 语法高亮颜色映射 (可根据你的编辑器主题调整)
@@ -15,7 +16,11 @@ const TOKEN_COLORS: Record<string, string> = {
 	default: "rgba(128, 128, 128, 0.5)", // 默认灰
 };
 
-export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
+export const Minimap: React.FC<MinimapProps> = ({
+	editor,
+	enabled,
+	mode = "always",
+}) => {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const sliderRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -364,7 +369,9 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 	return (
 		<div
 			ref={containerRef}
-			className="ace-minimap-container"
+			className={`ace-minimap-container ${
+				mode === "hover" ? "ace-minimap-hover-mode" : ""
+			}`}
 			onMouseEnter={() => setIsHovering(true)}
 			onMouseLeave={() => {
 				if (!isDragging) setIsHovering(false);
@@ -378,7 +385,9 @@ export const Minimap: React.FC<MinimapProps> = ({ editor, enabled }) => {
 			<div
 				ref={sliderRef}
 				className={`ace-minimap-slider ${
-					isHovering || isDragging ? "visible" : ""
+					mode === "always" || isHovering || isDragging
+						? "visible"
+						: ""
 				} ${isDragging ? "dragging" : ""}`}
 				onMouseDown={handleSliderMouseDown}
 			/>

--- a/styles/Minimap.css
+++ b/styles/Minimap.css
@@ -12,6 +12,15 @@
 	box-sizing: border-box;
 }
 
+/* Hover Mode: Default hidden, show on hover */
+.ace-minimap-container.ace-minimap-hover-mode {
+	opacity: 0;
+}
+
+.ace-minimap-container.ace-minimap-hover-mode:hover {
+	opacity: 1;
+}
+
 .ace-minimap-canvas {
 	display: block;
 	width: 100%;


### PR DESCRIPTION
为缩略图功能新增“mode”配置，支持三种显示模式：
always（始终显示）、hover（悬停时显示）、hidden（隐藏）。在类型定义、
国际化（中/繁/英）和默认设置中添加对应字段与翻译，保证类型安全
与多语言支持。

在设置界面将启用开关替换为下拉选择，使用户可直接选择显示模式。
选择 hidden 时自动禁用缩略图并保持默认 mode；选择其他模式时启用
缩略图并保存所选模式，提升交互一致性与可用性。

在 Minimap 组件中引入 mode 属性，按模式调整可见性和样式：
- hover 模式下容器默认透明，仅在悬停或拖动时显示滑块；
- always 模式始终显示滑块与缩略图。
同时更新样式表与组件类名以实现上述行为。

这些改动的目的是提供更灵活的缩略图显示策略，改善用户体验
并保证配置与渲染逻辑一致。