### PR TITLE
docs: fix README/README-zh formatting and add links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,17 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+ko_fi: ravenhogwarts
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
 custom: ["https://afdian.com/a/ravenhogwarts"]

--- a/README-zh.md
+++ b/README-zh.md
@@ -2,7 +2,7 @@
 
 # ACE 代码编辑器
 
-一个基于Ace编辑器增强的代码编辑器，提供语法高亮、代码折叠等高级编辑功能。
+一个基于 Ace 编辑器增强的代码编辑器，提供语法高亮、代码折叠等高级编辑功能。
 
 [![GitHub stars](https://img.shields.io/github/stars/RavenHogWarts/obsidian-ace-code-editor?style=flat&label=星标)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/stargazers)
 [![Total Downloads](https://img.shields.io/github/downloads/RavenHogWarts/obsidian-ace-code-editor/total?style=flat&label=总下载量)](https://github.com/RavenHogWarts/obsidian-ace-code-editor/releases)
@@ -13,19 +13,20 @@
 
 ## 功能介绍
 
-- 在 obsidian 中直接进行代码编辑
-![](./assets/code_view_leaf.png)
+-   在 obsidian 中直接进行代码编辑
+    ![](./assets/code_view_leaf.png)
 
-- 管理 css 代码片段
-![](./assets/snippet_manager.png)
+-   管理 css 代码片段
+    ![](./assets/snippet_manager.png)
 
-- 编辑代码块
-![](./assets/code_block_edit.png)
+-   编辑代码块
+    ![](./assets/code_block_edit.png)
 
-- 代码文件预览
-![](./assets/code_file_preview.png)
+-   代码文件预览
+    ![](./assets/code_file_preview.png)
 
 ## 安装
+
 ### 手动安装
 
 1. 下载最新版本
@@ -34,6 +35,7 @@
 4. 在设置 → 社区插件中启用插件
 
 ### BRAT（推荐给测试用户）
+
 1. 安装 [BRAT](https://github.com/TfTHacker/obsidian42-brat) 插件
 2. 在 BRAT 设置中点击"添加测试插件"
 3. 输入 `RavenHogWarts/obsidian-ace-code-editor`
@@ -41,24 +43,26 @@
 
 ## 开发指南
 
-- 克隆此仓库
-- 确保你的 NodeJS 版本至少为 v16 (`node --version`)
-- 使用 `npm i` 或 `yarn` 安装依赖
-- 使用 `npm run dev` 启动开发模式并进行实时编译
-- 运行 `npm run build` 构建插件
-- 运行 `npm run build:local` 构建插件并将其复制到您的 vault 插件文件夹（需要在项目根目录创建一个 `.env` 文件并添加：`VAULT_PATH=/path/to/your/vault`）
-- 运行 `npm run version` 更新版本号并更新 manifest.json、version.json、package.json
-- 运行 `npm run release` 构建插件并更新版本号
+-   克隆此仓库
+-   确保你的 NodeJS 版本至少为 v16 (`node --version`)
+-   使用 `npm i` 或 `yarn` 安装依赖
+-   使用 `npm run dev` 启动开发模式并进行实时编译
+-   运行 `npm run build` 构建插件
+-   运行 `npm run build:local` 构建插件并将其复制到您的 vault 插件文件夹（需要在项目根目录创建一个 `.env` 文件并添加：`VAULT_PATH=/path/to/your/vault`）
+-   运行 `npm run version` 更新版本号并更新 manifest.json、version.json、package.json
+-   运行 `npm run release` 构建插件并更新版本号
 
 ## 支持与帮助
 
 如果你遇到任何问题或有建议：
-- [在 GitHub 上提交问题](https://github.com/RavenHogWarts/obsidian-ace-code-editor/issues)
-- [加入讨论](https://github.com/RavenHogWarts/obsidian-ace-code-editor/discussions) 提出问题或分享想法
-- [查看贡献指南](./CONTRIBUTING.md) 如果你想为项目做出贡献
+
+-   [在 GitHub 上提交问题](https://github.com/RavenHogWarts/obsidian-ace-code-editor/issues)
+-   [加入讨论](https://github.com/RavenHogWarts/obsidian-ace-code-editor/discussions) 提出问题或分享想法
+-   [查看贡献指南](./CONTRIBUTING.md) 如果你想为项目做出贡献
 
 如果你觉得这个插件对你有帮助，可以通过以下方式支持开发：
-- [爱发电](https://afdian.com/a/ravenhogwarts)
+
+-   [爱发电](https://afdian.com/a/ravenhogwarts)
 
 ## 许可证
 

--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@ An enhanced code editor using Ace editor, providing syntax highlighting, code fo
 
 ## Features
 
-- Edit code directly in Obsidian
-![](./assets/code_view_leaf.png)
+-   Edit code directly in Obsidian
+    ![](./assets/code_view_leaf.png)
 
-- Manage CSS snippets
-![](./assets/snippet_manager.png)
+-   Manage CSS snippets
+    ![](./assets/snippet_manager.png)
 
-- Edit code blocks
-![](./assets/code_block_edit.png)
+-   Edit code blocks
+    ![](./assets/code_block_edit.png)
 
-- Code file preview
-![](./assets/code_file_preview.png)
+-   Code file preview
+    ![](./assets/code_file_preview.png)
 
 ## Installation
+
 ### Manual Installation
 
 1. Download the latest release
@@ -34,6 +35,7 @@ An enhanced code editor using Ace editor, providing syntax highlighting, code fo
 4. Enable the plugin in Settings → Community Plugins
 
 ### BRAT (Recommended for Beta Users)
+
 1. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin
 2. Click "Add Beta plugin" in BRAT settings
 3. Enter `RavenHogWarts/obsidian-ace-code-editor`
@@ -41,24 +43,27 @@ An enhanced code editor using Ace editor, providing syntax highlighting, code fo
 
 ## Development
 
-- Clone this repo
-- Make sure your NodeJS is at least v16 (`node --version`)
-- `npm i` or `yarn` to install dependencies
-- `npm run dev` to start compilation in watch mode
-- `npm run build` to build the plugin
-- `npm run build:local` to build the plugin and copy it to your vault's plugins folder(need create a .env file in the project root and add the line: VAULT_PATH=/path/to/your/vault)
-- `npm run version` to bump the version number and update the manifest.json, version.json, package.json
-- `npm run release` to build the plugin and bump the version number
+-   Clone this repo
+-   Make sure your NodeJS is at least v16 (`node --version`)
+-   `npm i` or `yarn` to install dependencies
+-   `npm run dev` to start compilation in watch mode
+-   `npm run build` to build the plugin
+-   `npm run build:local` to build the plugin and copy it to your vault's plugins folder(need create a .env file in the project root and add the line: VAULT_PATH=/path/to/your/vault)
+-   `npm run version` to bump the version number and update the manifest.json, version.json, package.json
+-   `npm run release` to build the plugin and bump the version number
 
 ## Support
 
 If you encounter any issues or have suggestions:
-- [Open an issue](https://github.com/RavenHogWarts/obsidian-ace-code-editor/issues) on GitHub
-- [Join the discussion](https://github.com/RavenHogWarts/obsidian-ace-code-editor/discussions) for questions and ideas
-- [Check the contributing guidelines](./CONTRIBUTING.md) if you'd like to contribute to the project
+
+-   [Open an issue](https://github.com/RavenHogWarts/obsidian-ace-code-editor/issues) on GitHub
+-   [Join the discussion](https://github.com/RavenHogWarts/obsidian-ace-code-editor/discussions) for questions and ideas
+-   [Check the contributing guidelines](./CONTRIBUTING.md) if you'd like to contribute to the project
 
 If you find this plugin helpful, you can support the development through:
-- [afdian](https://afdian.com/a/ravenhogwarts)
+
+-   [ko-fi](https://ko-fi.com/ravenhogwarts)
+-   [afdian](https://afdian.com/a/ravenhogwarts)
 
 ## License
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -7,6 +7,7 @@
 	"author": "RavenHogWarts",
 	"authorUrl": "https://github.com/RavenHogWarts",
 	"fundingUrl": {
+		"ko-fi": "https://ko-fi.com/ravenhogwarts",
 		"afdian": "https://afdian.com/a/ravenhogwarts"
 	},
 	"isDesktopOnly": false

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
 	"author": "RavenHogWarts",
 	"authorUrl": "https://github.com/RavenHogWarts",
 	"fundingUrl": {
+		"ko-fi": "https://ko-fi.com/ravenhogwarts",
 		"afdian": "https://afdian.com/a/ravenhogwarts"
 	},
 	"isDesktopOnly": false


### PR DESCRIPTION
修复 README 与 README-zh 中列表和图片的缩进、对齐问题，统一
项目文档的排版风格。此更改将：

- 将功能列表、开发指南和支持链接的项目前添加一致的两个空格
  缩进，修正图片旁边的 Markdown 缩进以保证渲染时显示正确。
- 在 README 中补充空行以改善章节间隔阅读体验。
- 在支持部分调整链接顺序并加入 ko-fi 链接，便于用户查找资助
  途径。

这样做是为了提升文档的可读性和在不同渲染器（如 GitHub 与 Obsi
dian）中的显示一致性，减少格式错位带来的视觉混乱，并让用户更
容易找到安装与支持信息。