### PR TITLE
fix: 修复搜索面板在右侧对齐问题

### DIFF
--- a/styles/AceView.css
+++ b/styles/AceView.css
@@ -3,3 +3,8 @@
 		overflow: hidden;
 	}
 }
+
+.ace_search.right {
+	right: auto !important;
+	left: 20px !important;
+}


### PR DESCRIPTION
调整 AceView.css，使搜索面板在右侧时改为从左侧偏移显示，
避免被编辑器右侧边距或滚动条遮挡。通过覆盖 .ace_search.right
的 right 属性并设置 left: 20px，确保在不同布局下搜索框
位置一致，改善可见性和可用性。