### PR TITLE
feat: 监听 css-change 事件并刷新片段文件列表

### DIFF
--- a/src/component/snippets/SnippetsNavigation.tsx
+++ b/src/component/snippets/SnippetsNavigation.tsx
@@ -100,6 +100,17 @@ export const SnippetsNavigation: React.FC<SnippetsNavigationProps> = ({
 		loadFiles();
 	}, [loadFiles]);
 
+	// 监听 css-change 事件
+	useEffect(() => {
+		const handleCssChange = () => {
+			loadFiles();
+		};
+		plugin.app.workspace.on("css-change", handleCssChange);
+		return () => {
+			plugin.app.workspace.off("css-change", handleCssChange);
+		};
+	}, [plugin.app, loadFiles]);
+
 	const sortedFiles = useMemo(() => {
 		return [...files].sort((a, b) => {
 			switch (sortType) {


### PR DESCRIPTION
在 SnippetsNavigation 组件中添加对 css-change 事件的监听，
当收到事件时调用 loadFiles新片段文件。为避免
存泄漏，使用 useEffect 在组件卸载或依赖变化时移除监听器。

这样可以在外部或主题变更触发 CSS 更新时即时同步片段
显示，提升界面一致性和用户体验。