### PR TITLE
feat: 添加可切换状态的 Action 支持

### DIFF
--- a/src/component/snippets/SnippetsNavigation.tsx
+++ b/src/component/snippets/SnippetsNavigation.tsx
@@ -488,10 +488,7 @@ export const SnippetsNavigation: React.FC<SnippetsNavigationProps> = ({
 									className="svg-icon mod-success"
 								/>
 							) : (
-								<EyeClosed
-									size={24}
-									className="svg-icon mod-warning"
-								/>
+								<EyeClosed size={24} className="svg-icon" />
 							)}
 						</div>
 						<div

--- a/src/view/AceEditorView.tsx
+++ b/src/view/AceEditorView.tsx
@@ -106,6 +106,20 @@ export abstract class AceEditorView extends TextFileView {
 
 			this.registerDomEvents(container);
 		}
+
+		this.addActions();
+	}
+
+	protected addActions() {
+		this.addToggleAction(
+			"map",
+			"Toggle minimap",
+			() => this.config.minimap.enabled,
+			(enabled) => {
+				this.config.minimap.enabled = enabled;
+				this.updateEditorConfig(this.config);
+			}
+		);
 	}
 
 	protected renderMinimap() {
@@ -213,5 +227,35 @@ export abstract class AceEditorView extends TextFileView {
 		}
 		this.config.fontSize = newFontSize;
 		this.plugin.updateSettings({ fontSize: newFontSize });
+	}
+
+	/**
+	 * 添加一个带状态切换的 Action 按钮
+	 * @param icon 图标名称
+	 * @param title 鼠标悬停提示
+	 * @param getState 获取当前状态的函数
+	 * @param onToggle 状态切换时的回调，参数为新状态
+	 * @returns 包含 element 和 refresh 方法的对象
+	 */
+	protected addToggleAction(
+		icon: string,
+		title: string,
+		getState: () => boolean,
+		onToggle: (newState: boolean) => void
+	): { element: HTMLElement; refresh: () => void } {
+		const actionEl = this.addAction(icon, title, () => {
+			const newState = !getState();
+			onToggle(newState);
+			actionEl.toggleClass("mod-success", newState);
+		});
+
+		const refresh = () => {
+			actionEl.toggleClass("mod-success", getState());
+		};
+
+		// 初始化时同步状态
+		refresh();
+
+		return { element: actionEl, refresh };
 	}
 }


### PR DESCRIPTION
在 AceEditorView 和 SnippetsEditorView 中新增并复用一个带状态切换
的 Action 方法，用于添加可反映并切换布尔状态的按钮（addToggleAction）。
主要改动：
- 在 AceEditorView 中增加 addActions 和 addToggleAction，封装了
  toggle 类型按钮的创建、初始化状态同步和刷新逻辑，并在最小化
  地图（minimap）按钮上使用。
- 优化 SnippetsEditorView：
  - 将旧的 toggleSnippetAction 重构为使用 addToggleAction，返回
    refresh 方法以便外部触发状态同步。
  - 移除冗余的 updateToggleAction 实现，改为用 refresh 回调在
    CSS 变化或文件切换时刷新状态。
  - 调整 addActions 调用顺序并确保继承父类行为（super.addActions）。
- 修正 SnippetsNavigation 中 EyeClosed 图标的类名，移除 mod-warning
  类以统一样式。

为什么做这些改动：
- 将重复的“切换并显示状态”逻辑抽象为可复用的方法，降低代码
  复本并提高可维护性。
- 通过返回 refresh 回调实现更灵活的外部状态同步，避免手动操
  作 DOM 属性，提高可靠性。