### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -100,9 +100,15 @@ export default class SettingsStore {
 		const pathParts = path.split(".");
 		let current: unknown = newSettings;
 
+		const isDangerousKey = (key: string): boolean =>
+			key === "__proto__" || key === "constructor" || key === "prototype";
+
 		// 遍历路径，找到父对象
 		for (let i = 0; i < pathParts.length - 1; i++) {
 			const part = pathParts[i];
+			if (isDangerousKey(part)) {
+				throw new Error(`Invalid setting path: ${path}`);
+			}
 			if (
 				typeof current === "object" &&
 				current !== null &&
@@ -112,6 +118,9 @@ export default class SettingsStore {
 			} else {
 				throw new Error(`Invalid setting path: ${path}`);
 			}
+		}
+		if (isDangerousKey(finalPart)) {
+			throw new Error(`Invalid setting path: ${path}`);
 		}
 
 		// 设置最终值


### PR DESCRIPTION
Potential fix for [https://github.com/Raven-Pensieve/obsidian-ace-code-editor/security/code-scanning/1](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/security/code-scanning/1)

In general, deep-assignment or path-based update helpers must prevent user-controlled keys from writing to critical prototype-related properties like `__proto__`, `constructor`, or `prototype`. This can be done by rejecting such keys outright or by constraining the set of allowed keys to a known safe list.

For this specific function, the smallest, safest fix is to add an explicit guard that forbids any path segment (both intermediate `part` and final `finalPart`) from being one of the known dangerous keys. If such a key is encountered, we can throw an error, which is consistent with the existing behavior when a path is invalid. This preserves existing functionality for all legitimate paths, while blocking prototype-polluting paths.

Concretely, in `src/settings/SettingsStore.ts` inside `updateSettingByPath`:

1. Define a small helper (inside the method) or inline check to test whether a path segment is dangerous: `__proto__`, `constructor`, or `prototype`.
2. In the loop (around line 105), before using `part` to index into `current`, check `if (isDangerousKey(part)) throw new Error(...)`.
3. Before using `finalPart` to assign into `current` (around line 119), also check for a dangerous key and throw if found.

No new imports are needed; this is pure TypeScript/JavaScript logic. The changes are entirely within `updateSettingByPath` and do not affect other methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
