### PR TITLE
feat(editor): 优化编辑器生命周期管理

### DIFF
--- a/src/view/AceEditorView.tsx
+++ b/src/view/AceEditorView.tsx
@@ -14,7 +14,6 @@ export abstract class AceEditorView extends TextFileView {
 
 	private minimapRoot: Root | null = null;
 	private minimapContainer: HTMLElement | null = null;
-	private actionsAdded: boolean = false;
 
 	constructor(
 		leaf: WorkspaceLeaf,
@@ -38,6 +37,9 @@ export abstract class AceEditorView extends TextFileView {
 	async onOpen() {
 		await super.onOpen();
 
+		// 初始化编辑器（只执行一次）
+		this.init();
+
 		this.registerEvent(
 			this.app.workspace.on("css-change", () => {
 				this.aceService.updateTheme(
@@ -52,13 +54,16 @@ export abstract class AceEditorView extends TextFileView {
 
 	async onUnloadFile(file: TFile) {
 		await super.onUnloadFile(file);
-		this.unmountMinimap();
-		this.aceService.destroy();
+		// 不销毁编辑器，因为同一个视图可能会加载新文件
+		// 只清空内容
+		this.clear();
 	}
 
 	async onClose() {
 		await super.onClose();
 		this.unmountMinimap();
+		// 关闭视图时销毁编辑器
+		this.aceService.destroy();
 	}
 
 	onResize() {
@@ -115,11 +120,6 @@ export abstract class AceEditorView extends TextFileView {
 	}
 
 	protected addActions() {
-		if (this.actionsAdded) {
-			return;
-		}
-		this.actionsAdded = true;
-
 		this.addToggleAction(
 			"map",
 			"Toggle minimap",

--- a/src/view/CodeEditorView.tsx
+++ b/src/view/CodeEditorView.tsx
@@ -13,7 +13,13 @@ export class CodeEditorView extends AceEditorView {
 	}
 
 	async onLoadFile(file: TFile): Promise<void> {
-		this.init();
+		// 只配置编辑器，不重新初始化
+		if (this.aceService.isEditorInitialized()) {
+			this.aceService.configureEditor(
+				this.config,
+				this.getFileExtension(file)
+			);
+		}
 
 		await super.onLoadFile(file);
 	}


### PR DESCRIPTION
修改编辑器视图的初始化和销毁逻辑，提高性能和资源利用率。主要变更包括：

仅在必要时初始化编辑器，避免重复初始化
优化文件加载和卸载时的编辑器行为
移除不必要的状态跟踪标志
在关闭视图时正确销毁编辑器资源

fixed #94