### PR TITLE
docs: 用GitHub Socialify 替换徽章

### DIFF
--- a/README.ZH.md
+++ b/README.ZH.md
@@ -4,12 +4,7 @@
 
 一个基于 Ace 编辑器增强的代码编辑器，提供语法高亮、代码折叠等高级编辑功能。
 
-[![GitHub stars](https://img.shields.io/github/stars/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=星标)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/stargazers)
-[![Total Downloads](https://img.shields.io/github/downloads/Raven-Pensieve/obsidian-ace-code-editor/total?style=flat&label=总下载量)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/releases)
-[![Latest Downloads](https://img.shields.io/github/downloads/Raven-Pensieve/obsidian-ace-code-editor/latest/total?style=flat&label=最新版下载量)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/releases/latest)
-[![GitHub License](https://img.shields.io/github/license/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=许可证)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/blob/master/LICENSE)
-[![GitHub Issues](https://img.shields.io/github/issues/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=问题)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/issues)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=最后提交)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/commits/master)
+![GitHub Socialify](https://socialify.git.ci/Raven-Pensieve/obsidian-ace-code-editor/image?description=1&font=Rokkitt&forks=1&issues=1&language=1&name=1&owner=1&pattern=Floating+Cogs&pulls=1&stargazers=1&theme=Auto)
 
 ## 功能介绍
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@ English | [中文](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/bl
 
 An enhanced code editor using Ace editor, providing syntax highlighting, code folding, and other advanced editing features.
 
-[![GitHub stars](https://img.shields.io/github/stars/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=Stars)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/stargazers)
-[![Total Downloads](https://img.shields.io/github/downloads/Raven-Pensieve/obsidian-ace-code-editor/total?style=flat&label=Total%20Downloads)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/releases)
-[![Latest Downloads](https://img.shields.io/github/downloads/Raven-Pensieve/obsidian-ace-code-editor/latest/total?style=flat&label=Latest%20Downloads)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/releases/latest)
-[![GitHub License](https://img.shields.io/github/license/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=License)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/blob/master/LICENSE)
-[![GitHub Issues](https://img.shields.io/github/issues/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=Issues)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/issues)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/Raven-Pensieve/obsidian-ace-code-editor?style=flat&label=Last%20Commit)](https://github.com/Raven-Pensieve/obsidian-ace-code-editor/commits/master)
+![GitHub Socialify](https://socialify.git.ci/Raven-Pensieve/obsidian-ace-code-editor/image?description=1&font=Rokkitt&forks=1&issues=1&language=1&name=1&owner=1&pattern=Floating+Cogs&pulls=1&stargazers=1&theme=Auto)
 
 ## Features
 


### PR DESCRIPTION
移除了多个独立的 GitHub 徽章，改用 GitHub Socialify
生成的单一社交卡片。这样可以简化 README结构，提供更
美观的项目展示效果，同时减少维护多个徽章链接的复杂性。